### PR TITLE
Add GitHub Pages issue tracker and workflow deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ OR just open an **Issue** with the template to pitch something new!
 
 ---
 
+## 🌐 Issue Tracker
+
+Browse existing issues and create new ones from our GitHub Pages site:
+
+```
+https://YOUR-USERNAME.github.io/holiday-adventures/
+```
+
+To submit an issue, provide a personal access token with `repo` scope in the page's authentication section. The token is saved only in your browser storage under the key `HOLIDAY_TOKEN`.
+
+This static site is published from the `docs/` directory via a GitHub Actions workflow that deploys the build to the `gh-pages` branch.
+
+---
+
 ## ❤️ This Project
 
 Built by MGeee and co-planned with Kayleigh 🌅

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,147 @@
+const owner = window.location.hostname.split('.')[0];
+const repo = window.location.pathname.split('/')[1] || 'holiday-adventures';
+
+function getHolidayToken() {
+  return localStorage.getItem('HOLIDAY_TOKEN') || '';
+}
+
+async function loadIssues(headers) {
+  const listEl = document.getElementById('issues-list');
+  listEl.innerHTML = '';
+  try {
+    const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, { headers });
+    if (!res.ok) throw new Error('Failed to fetch issues');
+    const issues = await res.json();
+    issues.forEach(issue => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = issue.html_url;
+      a.textContent = issue.title;
+      a.target = '_blank';
+      li.appendChild(a);
+      listEl.appendChild(li);
+    });
+  } catch (err) {
+    const li = document.createElement('li');
+    li.textContent = 'Unable to load issues';
+    listEl.appendChild(li);
+    console.error(err);
+  }
+}
+
+async function loadProjectBoard(headers) {
+  const boardEl = document.getElementById('project-columns');
+  boardEl.innerHTML = '';
+  try {
+    const projectRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/projects`, {
+      headers: { ...headers, Accept: 'application/vnd.github.inertia-preview+json' }
+    });
+    if (!projectRes.ok) throw new Error('Failed to fetch projects');
+    const projects = await projectRes.json();
+    for (const project of projects) {
+      const projectDiv = document.createElement('div');
+      projectDiv.className = 'project';
+      const projectTitle = document.createElement('h3');
+      projectTitle.textContent = project.name;
+      projectDiv.appendChild(projectTitle);
+
+      const columnsRes = await fetch(project.columns_url, {
+        headers: { ...headers, Accept: 'application/vnd.github.inertia-preview+json' }
+      });
+      if (!columnsRes.ok) continue;
+      const columns = await columnsRes.json();
+      const columnsContainer = document.createElement('div');
+      columnsContainer.className = 'columns';
+      for (const column of columns) {
+        const columnDiv = document.createElement('div');
+        columnDiv.className = 'column';
+        const columnTitle = document.createElement('h4');
+        columnTitle.textContent = column.name;
+        columnDiv.appendChild(columnTitle);
+
+        const cardsRes = await fetch(column.cards_url, {
+          headers: { ...headers, Accept: 'application/vnd.github.inertia-preview+json' }
+        });
+        if (cardsRes.ok) {
+          const cards = await cardsRes.json();
+          const ul = document.createElement('ul');
+          for (const card of cards) {
+            const li = document.createElement('li');
+            if (card.content_url) {
+              const contentRes = await fetch(card.content_url, { headers });
+              if (contentRes.ok) {
+                const content = await contentRes.json();
+                const link = document.createElement('a');
+                link.href = content.html_url;
+                link.textContent = content.title;
+                link.target = '_blank';
+                li.appendChild(link);
+              } else {
+                li.textContent = 'Item';
+              }
+            } else {
+              li.textContent = card.note || 'Card';
+            }
+            ul.appendChild(li);
+          }
+          columnDiv.appendChild(ul);
+        }
+        columnsContainer.appendChild(columnDiv);
+      }
+      projectDiv.appendChild(columnsContainer);
+      boardEl.appendChild(projectDiv);
+    }
+  } catch (err) {
+    boardEl.textContent = 'Unable to load project board';
+    console.error(err);
+  }
+}
+
+function loadData() {
+  const token = getHolidayToken();
+  const headers = token ? { Authorization: `token ${token}` } : {};
+  loadIssues(headers);
+  loadProjectBoard(headers);
+}
+
+document.getElementById('save-token').addEventListener('click', () => {
+  const tokenInput = document.getElementById('token-input');
+  const val = tokenInput.value.trim();
+  if (val) {
+    localStorage.setItem('HOLIDAY_TOKEN', val);
+    tokenInput.value = '';
+    loadData();
+  }
+});
+
+document.getElementById('issue-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const token = getHolidayToken();
+  if (!token) {
+    alert('Please save a token first.');
+    return;
+  }
+  const title = document.getElementById('issue-title').value;
+  const body = document.getElementById('issue-body').value;
+  const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
+    method: 'POST',
+    headers: {
+      Authorization: `token ${token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ title, body })
+  });
+  const resultEl = document.getElementById('issue-result');
+  if (res.ok) {
+    const data = await res.json();
+    resultEl.innerHTML = `Issue created: <a href="${data.html_url}" target="_blank">${data.number}</a>`;
+    document.getElementById('issue-form').reset();
+    loadData();
+  } else {
+    const err = await res.json();
+    resultEl.textContent = `Error: ${err.message}`;
+  }
+});
+
+// Initial load
+loadData();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Holiday Adventures Issue Tracker</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Holiday Adventures Issue Tracker</h1>
+
+  <section id="token">
+    <h2>Authentication</h2>
+    <p>Enter a GitHub personal access token with <code>repo</code> scope. The token is stored only in this browser as <code>HOLIDAY_TOKEN</code> in <code>localStorage</code>.</p>
+    <input type="password" id="token-input" placeholder="HOLIDAY_TOKEN" />
+    <button id="save-token">Save Token</button>
+  </section>
+
+  <section id="issues">
+    <h2>Existing Issues</h2>
+    <ul id="issues-list"></ul>
+  </section>
+
+  <section id="project-board">
+    <h2>Project Board</h2>
+    <div id="project-columns"></div>
+  </section>
+
+  <section id="new-issue">
+    <h2>Submit a New Issue</h2>
+    <form id="issue-form">
+      <label>
+        Title
+        <input type="text" id="issue-title" required />
+      </label>
+      <label>
+        Description
+        <textarea id="issue-body" required></textarea>
+      </label>
+      <button type="submit">Create Issue</button>
+    </form>
+    <div id="issue-result"></div>
+  </section>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,19 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+.columns {
+  display: flex;
+  gap: 1rem;
+}
+
+.column {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  width: 200px;
+}


### PR DESCRIPTION
## Summary
- Add GitHub Pages site to view issues, project board and create new issues
- Store GitHub token locally and use GitHub API for issue creation
- Use HOLIDAY_TOKEN key for browser-stored credentials and document usage
- Configure GitHub Actions workflow to publish `docs/` to `gh-pages`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68912c47e6f88328acc68c31a562d4a6