### PR TITLE
Add Holiday Bits section and fetch repository resources

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -97,11 +97,51 @@ async function loadProjectBoard(headers) {
   }
 }
 
+async function loadHolidayBits(headers) {
+  const container = document.getElementById('holiday-bits-container');
+  if (!container) return;
+  container.innerHTML = '';
+  const sections = [
+    { path: 'destinations', title: 'Destinations' },
+    { path: 'ideas', title: 'Ideas' },
+    { path: 'packing-lists', title: 'Packing Lists' },
+    { path: 'itinerary-templates', title: 'Itinerary Templates' }
+  ];
+  for (const { path, title } of sections) {
+    try {
+      const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, { headers });
+      if (!res.ok) continue;
+      const files = await res.json();
+      const sectionDiv = document.createElement('div');
+      const h3 = document.createElement('h3');
+      h3.textContent = title;
+      sectionDiv.appendChild(h3);
+      const ul = document.createElement('ul');
+      files.forEach(file => {
+        if (file.type === 'file') {
+          const li = document.createElement('li');
+          const a = document.createElement('a');
+          a.href = file.html_url;
+          a.textContent = file.name;
+          a.target = '_blank';
+          li.appendChild(a);
+          ul.appendChild(li);
+        }
+      });
+      sectionDiv.appendChild(ul);
+      container.appendChild(sectionDiv);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+}
+
 function loadData() {
   const token = getHolidayToken();
   const headers = token ? { Authorization: `token ${token}` } : {};
   loadIssues(headers);
   loadProjectBoard(headers);
+  loadHolidayBits(headers);
 }
 
 document.getElementById('save-token').addEventListener('click', () => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,6 +26,11 @@
     <div id="project-columns"></div>
   </section>
 
+  <section id="holiday-bits">
+    <h2>Holiday Bits</h2>
+    <div id="holiday-bits-container"></div>
+  </section>
+
   <section id="new-issue">
     <h2>Submit a New Issue</h2>
     <form id="issue-form">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -7,6 +7,19 @@ section {
   margin-bottom: 2rem;
 }
 
+#holiday-bits div {
+  margin-bottom: 1rem;
+}
+
+#holiday-bits ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+#holiday-bits a {
+  color: #006400;
+}
+
 .columns {
   display: flex;
   gap: 1rem;


### PR DESCRIPTION
## Summary
- Add "Holiday Bits" section to docs index to showcase destinations, ideas, packing lists, and templates
- Implement `loadHolidayBits` to fetch repository directories and render links
- Style new section to match holiday theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920530f73883289bd1676955e140d4