### PR TITLE
Switch to task terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,21 @@ holiday-adventures/
 3. Add or edit `.md` files with suggestions
 4. Open a pull request with your additions
 
-OR just open an **Issue** with the template to pitch something new!
+OR just open a **Task** with the template to pitch something new!
 
 ---
 
-## 🌐 Issue Tracker
+## 🌐 Task Tracker
 
-Browse existing issues and create new ones from our GitHub Pages site:
+Browse existing tasks (GitHub Issues) and create new ones from our GitHub Pages site:
 
 ```
 https://YOUR-USERNAME.github.io/holiday-adventures/
 ```
 
-To submit an issue, provide a personal access token with `repo` scope in the page's authentication section. The token is saved only in your browser storage under the key `HOLIDAY_TOKEN`.
+Tasks correspond to GitHub Issues, so you'll still see templates under `.github/ISSUE_TEMPLATE/` as required by GitHub.
+
+To submit a task, provide a personal access token with `repo` scope in the page's authentication section. The token is saved only in your browser storage under the key `HOLIDAY_TOKEN`.
 
 This static site is published from the `docs/` directory via a GitHub Actions workflow that deploys the build to the `gh-pages` branch.
 

--- a/docs/app.js
+++ b/docs/app.js
@@ -10,7 +10,7 @@ async function loadIssues(headers) {
   listEl.innerHTML = '';
   try {
     const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, { headers });
-    if (!res.ok) throw new Error('Failed to fetch issues');
+    if (!res.ok) throw new Error('Failed to fetch tasks');
     const issues = await res.json();
     issues.forEach(issue => {
       const li = document.createElement('li');
@@ -23,7 +23,7 @@ async function loadIssues(headers) {
     });
   } catch (err) {
     const li = document.createElement('li');
-    li.textContent = 'Unable to load issues';
+    li.textContent = 'Unable to load tasks';
     listEl.appendChild(li);
     console.error(err);
   }
@@ -174,7 +174,7 @@ document.getElementById('issue-form').addEventListener('submit', async (e) => {
   const resultEl = document.getElementById('issue-result');
   if (res.ok) {
     const data = await res.json();
-    resultEl.innerHTML = `Issue created: <a href="${data.html_url}" target="_blank">${data.number}</a>`;
+    resultEl.innerHTML = `Task created: <a href="${data.html_url}" target="_blank">${data.number}</a>`;
     document.getElementById('issue-form').reset();
     loadData();
   } else {

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,11 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Holiday Adventures Issue Tracker</title>
+  <title>Holiday Adventures Task Tracker</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <h1>Holiday Adventures Issue Tracker</h1>
+  <h1>Holiday Adventures Task Tracker</h1>
+  <p>Tasks are tracked as GitHub Issues, so templates live in <code>.github/ISSUE_TEMPLATE/</code>.</p>
 
   <section id="token">
     <h2>Authentication</h2>
@@ -17,7 +18,7 @@
   </section>
 
   <section id="issues">
-    <h2>Existing Issues</h2>
+    <h2>Existing Tasks</h2>
     <ul id="issues-list"></ul>
   </section>
 
@@ -32,7 +33,7 @@
   </section>
 
   <section id="new-issue">
-    <h2>Submit a New Issue</h2>
+    <h2>Submit a New Task</h2>
     <form id="issue-form">
       <label>
         Title
@@ -42,7 +43,7 @@
         Description
         <textarea id="issue-body" required></textarea>
       </label>
-      <button type="submit">Create Issue</button>
+      <button type="submit">Create Task</button>
     </form>
     <div id="issue-result"></div>
   </section>


### PR DESCRIPTION
## Summary
- replace "issue" with "task" in contribution guide and tracker docs
- rename Issue Tracker section and page to Task Tracker, noting tasks map to GitHub Issues
- update tracker UI scripts to use task-focused messaging

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892062da4d883289916a300e1b41bf0