### PR TITLE
Add navigation and hero banner to documentation site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,9 +7,18 @@
 <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="banner">
-    <h1>🎄 Holiday Adventures Task Tracker 🎄</h1>
+  <header class="hero">
+    <img src="https://images.unsplash.com/photo-1541417904953-9e57f9ff675f?auto=format&fit=crop&w=1600&q=80" alt="Holiday lights" class="hero-image" />
+    <div class="hero-tagline">
+      <h1>🎄 Holiday Adventures Task Tracker 🎄</h1>
+      <p>Plan, track, and celebrate your festive projects</p>
+    </div>
   </header>
+  <nav class="main-nav">
+    <a href="#tasks">Tasks</a>
+    <a href="#project-board">Project Board</a>
+    <a href="#holiday-bits">Holiday Bits</a>
+  </nav>
   <section id="token">
     <h2>Authentication</h2>
     <p>Enter a GitHub personal access token with <code>repo</code> scope. The token is stored only in this browser as <code>HOLIDAY_TOKEN</code> in <code>localStorage</code>.</p>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -30,12 +30,47 @@ h2::before {
   margin-right: 0.5rem;
 }
 
-.banner {
-  text-align: center;
-  padding: 1rem;
-  background: rgba(0, 0, 0, 0.2);
-  border-radius: 8px;
+.hero {
+  display: grid;
   margin-bottom: 2rem;
+}
+
+.hero-image {
+  width: 100%;
+  height: auto;
+  grid-area: 1 / 1;
+}
+
+.hero-tagline {
+  grid-area: 1 / 1;
+  place-self: center;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.main-nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 0.5rem;
+  border-radius: 8px;
+}
+
+.main-nav a {
+  color: #f0c419;
+  text-decoration: none;
+}
+
+@media (max-width: 600px) {
+  .main-nav {
+    flex-direction: column;
+    align-items: center;
+  }
 }
 
 #holiday-bits div {


### PR DESCRIPTION
## Summary
- Add hero banner with full-width holiday image and tagline
- Introduce navigation bar linking to Tasks, Project Board, and Holiday Bits sections
- Style new components with responsive grid and flex layouts

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68921ce2b4b883288f96489dc9e2f975