### PR TITLE
feat: add configurable repository options

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,5 +1,22 @@
-const owner = window.location.hostname.split('.')[0];
-const repo = window.location.pathname.split('/')[1] || 'holiday-adventures';
+// Configuration for repository information
+// Allow overrides via query parameters (e.g., ?owner=user&repo=project),
+// a global config object `window.HOLIDAY_CONFIG`, or environment variables
+// exposed on `window.ENV`. Falls back to parsing the current URL.
+const queryParams = new URLSearchParams(window.location.search);
+const globalConfig = window.HOLIDAY_CONFIG || {};
+const envConfig = (typeof window !== 'undefined' && (window.ENV || window.env)) || {};
+
+const owner =
+  queryParams.get('owner') ||
+  globalConfig.owner ||
+  envConfig.GITHUB_OWNER ||
+  window.location.hostname.split('.')[0];
+const repo =
+  queryParams.get('repo') ||
+  globalConfig.repo ||
+  envConfig.GITHUB_REPO ||
+  window.location.pathname.split('/')[1] ||
+  'holiday-adventures';
 
 function getHolidayToken() {
   return localStorage.getItem('HOLIDAY_TOKEN') || '';


### PR DESCRIPTION
## Summary
- add configuration block to override owner/repo via query params, global config, or environment
- continue using configured owner/repo for all GitHub API requests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689220bae6c8832880e02c51acc7948a