### PR TITLE
Refactor docs repo detection

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,5 +1,6 @@
 const owner = window.location.hostname.split('.')[0];
-const repo = window.location.pathname.split('/')[1] || 'holiday-adventures';
+const repoMeta = document.querySelector('meta[name="repo"]');
+const repo = repoMeta ? repoMeta.getAttribute('content') : 'holiday-adventures';
 
 function getHolidayToken() {
   return localStorage.getItem('HOLIDAY_TOKEN') || '';

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="repo" content="holiday-adventures" />
 <title>Adventure Holiday's Tracker</title>
 <link rel="stylesheet" href="styles.css" />
 </head>


### PR DESCRIPTION
## Summary
- Avoid using the pathname for repository detection in docs app
- Provide repository metadata via a meta tag

## Testing
- `node <inline test>`

------
https://chatgpt.com/codex/tasks/task_e_68922137f49883288fab38aa92f9e95a