### PR TITLE
feat: add images to docs sections

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,7 @@
   </nav>
   <section id="token">
     <h2>Authentication</h2>
+    <img src="https://source.unsplash.com/400x200/?lock" alt="Secure lock" class="section-image" loading="lazy" />
     <p>Enter a GitHub personal access token with <code>repo</code> scope. The token is stored only in this browser as <code>HOLIDAY_TOKEN</code> in <code>localStorage</code>.</p>
     <label for="token-input">Personal Access Token</label>
     <input type="password" id="token-input" placeholder="HOLIDAY_TOKEN" />
@@ -24,21 +25,25 @@
   </section>
   <section id="tasks">
     <h2>Existing Tasks</h2>
+    <img src="https://source.unsplash.com/400x200/?todo" alt="Checklist" class="section-image" loading="lazy" />
     <ul id="tasks-list"></ul>
   </section>
 
     <section id="project-board">
       <h2>Project Board</h2>
+      <img src="https://source.unsplash.com/400x200/?planning" alt="Project planning board" class="section-image" loading="lazy" />
       <div id="project-columns"></div>
     </section>
 
   <section id="holiday-bits">
     <h2>Travel Bits</h2>
+    <img src="https://source.unsplash.com/400x200/?travel" alt="Travel items" class="section-image" loading="lazy" />
     <div id="holiday-bits-container"></div>
   </section>
-  
+
   <section id="new-task">
     <h2>Submit a New Task</h2>
+    <img src="https://source.unsplash.com/400x200/?pencil" alt="Writing a new task" class="section-image" loading="lazy" />
     <form id="task-form">
       <label for="task-title">Title</label>
       <input type="text" id="task-title" required />

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -23,6 +23,16 @@ section {
   border-radius: 8px;
 }
 
+.section-image {
+  width: 100%;
+  max-width: 400px;
+  height: auto;
+  display: block;
+  margin: 0.5rem auto 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+}
+
 h1,
 h2 {
   font-family: 'Poppins', sans-serif;


### PR DESCRIPTION
## Summary
- add postcard-like images to main sections in docs
- style images to be responsive with subtle shadows

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6892213c4c688328a65e89fdad92d01a