### PR TITLE
Enhance docs section styling

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -9,6 +9,20 @@ body {
   color: #fff;
 }
 
+:root {
+  --section-bg-odd: rgba(255, 255, 255, 0.85);
+  --section-bg-even: rgba(245, 245, 245, 0.85);
+  --section-text: #000;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --section-bg-odd: rgba(0, 0, 0, 0.3);
+    --section-bg-even: rgba(0, 0, 0, 0.5);
+    --section-text: #fff;
+  }
+}
+
 .container {
   max-width: 1200px;
   margin: 0 auto;
@@ -17,10 +31,19 @@ body {
 
 section {
   margin-bottom: 2rem;
-  background: rgba(255, 255, 255, 0.1);
   border: 1px solid rgba(255, 183, 3, 0.4);
   padding: 1rem;
   border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  color: var(--section-text);
+}
+
+section:nth-of-type(odd) {
+  background: var(--section-bg-odd);
+}
+
+section:nth-of-type(even) {
+  background: var(--section-bg-even);
 }
 
 h1,
@@ -30,10 +53,29 @@ h2 {
   text-shadow: 1px 1px 2px #000;
 }
 
-h1::before,
 h2::before {
-  content: '\\2708';
+  display: inline-block;
   margin-right: 0.5rem;
+}
+
+#token h2::before {
+  content: '🔐';
+}
+
+#tasks h2::before {
+  content: '📋';
+}
+
+#project-board h2::before {
+  content: '🗂️';
+}
+
+#holiday-bits h2::before {
+  content: '🧳';
+}
+
+#new-task h2::before {
+  content: '➕';
 }
 
 .hero {


### PR DESCRIPTION
## Summary
- alternate section backgrounds with subtle shadows
- add section-specific heading icons
- support light and dark mode with improved contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892213d9b1c8328b267d66017c4e499