### PR TITLE
Deduplicate docs index sections

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -38,31 +38,6 @@
   <ul id="tasks-list"></ul>
 
   </section>
-  <div class="container">
-    <header class="banner">
-      <h1>✈️ Adventure Holiday's Tracker ✈️</h1>
-    </header>
-    <nav class="main-nav">
-      <a href="#tasks">Tasks</a>
-      <a href="#project-board">Project Board</a>
-      <a href="#holiday-bits">Holiday Bits</a>
-    </nav>
-    <section id="token">
-      <h2>Authentication</h2>
-      <p>Enter a GitHub personal access token with <code>repo</code> scope. The token is stored only in this browser as <code>HOLIDAY_TOKEN</code> in <code>localStorage</code>.</p>
-      <label for="token-input">Personal Access Token</label>
-      <input type="password" id="token-input" placeholder="HOLIDAY_TOKEN" />
-      <button id="save-token">Save Token</button>
-    </section>
-    <section id="tasks">
-      <h2>Existing Tasks</h2>
-      <ul id="tasks-list"></ul>
-    </section>
-
-      <section id="project-board">
-        <h2>Project Board</h2>
-        <div id="project-columns"></div>
-      </section>
 
 <section id="project-board">
   <h2>Project Board</h2>
@@ -88,7 +63,6 @@
   </form>
   <div id="task-result"></div>
 </section>
-</div>
 
 
   <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- remove redundant `<div class="container">` and duplicated header/nav blocks
- keep single instances of token, tasks, project board, holiday bits, and new task sections

## Testing
- `node -e "const fs=require('fs');const html=fs.readFileSync('docs/index.html','utf8');const ids=[...html.matchAll(/id=\"([^\"]+)\"/g)].map(m=>m[1]);const dups=ids.filter((id,i)=>ids.indexOf(id)!==i);console.log('IDs:',ids);console.log('Duplicate IDs:',[...new Set(dups)]);"`


------
https://chatgpt.com/codex/tasks/task_e_689248cd66e88328886c9ee8526136c5