### PR TITLE
feat: improve hero banner

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,11 @@
     </nav>
 
     <section class="hero">
-      <img class="hero-image" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/5+hHgAHggJ/PdLKoQAAAABJRU5ErkJggg==" alt="Scenic adventure" />
+      <img
+        class="hero-image"
+        src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=1600&h=600&q=80"
+        alt="Scenic adventure"
+      />
       <div class="hero-tagline">Your next adventure starts here</div>
     </section>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -95,8 +95,10 @@ h2::before {
 
 .hero-image {
   width: 100%;
-  height: auto;
+  height: 40vh;
+  object-fit: cover;
   grid-area: 1 / 1;
+  animation: fade-in 1.5s ease-in-out;
 }
 
 .hero-tagline {
@@ -106,6 +108,17 @@ h2::before {
   background: rgba(0, 0, 0, 0.4);
   padding: 1rem;
   border-radius: 8px;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: scale(1.05);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .main-nav {


### PR DESCRIPTION
## Summary
- replace base64 hero banner with Unsplash scenic image
- add responsive hero-image styling and fade-in animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924bd6a76c832885dbde8ab870b95e