### PR TITLE
refactor: consolidate sections into single container

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,22 +8,22 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <header class="banner">
+    <h1>✈️ Adventure Holiday's Tracker ✈️</h1>
+  </header>
+
+  <nav class="main-nav">
+    <a href="#tasks"><span class="nav-icon">📝</span>Tasks</a>
+    <a href="#project-board"><span class="nav-icon">📋</span>Project Board</a>
+    <a href="#holiday-bits"><span class="nav-icon">🎒</span>Holiday Bits</a>
+  </nav>
+
+  <section class="hero">
+    <img class="hero-image" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/5+hHgAHggJ/PdLKoQAAAABJRU5ErkJggg==" alt="Scenic adventure" />
+    <div class="hero-tagline">Your next adventure starts here</div>
+  </section>
+
   <div class="container">
-    <header class="banner">
-      <h1>✈️ Adventure Holiday's Tracker ✈️</h1>
-    </header>
-
-    <nav class="main-nav">
-      <a href="#tasks"><span class="nav-icon">📝</span>Tasks</a>
-      <a href="#project-board"><span class="nav-icon">📋</span>Project Board</a>
-      <a href="#holiday-bits"><span class="nav-icon">🎒</span>Holiday Bits</a>
-    </nav>
-
-    <section class="hero">
-      <img class="hero-image" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/5+hHgAHggJ/PdLKoQAAAABJRU5ErkJggg==" alt="Scenic adventure" />
-      <div class="hero-tagline">Your next adventure starts here</div>
-    </section>
-
     <section id="token">
       <h2>Authentication</h2>
       <img src="https://source.unsplash.com/400x200/?lock" alt="Secure lock" class="section-image" loading="lazy" />


### PR DESCRIPTION
## Summary
- move header and nav outside content container
- wrap unique sections in one container after hero

## Testing
- `python - <<'PY'
from bs4 import BeautifulSoup
with open('docs/index.html') as f:
    soup = BeautifulSoup(f, 'html.parser')
print('headers', len(soup.find_all('header', class_='banner')))
print('navs', len(soup.find_all('nav', class_='main-nav')))
print('token', len(soup.select('#token')))
print('tasks', len(soup.select('#tasks')))
print('project-board', len(soup.select('#project-board')))
print('holiday-bits', len(soup.select('#holiday-bits')))
print('new-task', len(soup.select('#new-task')))
PY`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68924bd4624c8328818a5e873bc2e359