### PR TITLE
Highlight active nav section on scroll

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -230,6 +230,21 @@ function loadData() {
   loadHolidayBits(headers);
 }
 
+function updateActiveNav() {
+  const links = document.querySelectorAll('.main-nav a');
+  let activeLink = null;
+  links.forEach(link => {
+    const section = document.querySelector(link.getAttribute('href'));
+    if (section) {
+      const rect = section.getBoundingClientRect();
+      if (rect.top <= window.innerHeight / 2 && rect.bottom >= window.innerHeight / 2) {
+        activeLink = link;
+      }
+    }
+  });
+  links.forEach(link => link.classList.toggle('active', link === activeLink));
+}
+
 const saveBtn = document.getElementById('save-token');
 if (saveBtn) {
   saveBtn.addEventListener('click', () => {
@@ -276,4 +291,8 @@ if (taskForm) {
 }
 
 // Initial load
-document.addEventListener('DOMContentLoaded', loadData);
+document.addEventListener('DOMContentLoaded', () => {
+  loadData();
+  updateActiveNav();
+});
+window.addEventListener('scroll', updateActiveNav);

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -142,12 +142,15 @@ h2::before {
   text-decoration: underline;  /* from Codex */
 }
 
-.main-nav a:focus,
-.main-nav a.active {
+.main-nav a:focus {
   outline: 3px solid #023047;  /* from main */
   outline-offset: 2px;         /* from main */
+}
+
+.main-nav a.active {
   background: #ffd166;         /* from main */
   color: #023047;              /* from main */
+  text-decoration: underline;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Highlight navigation links as their sections enter the viewport
- Style `.main-nav a.active` with a distinct background and underline while keeping keyboard focus outlines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924bd8b01c8328986582e9cb10be1a