### PR TITLE
Refactor theme initialization for system updates

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -21,21 +21,42 @@ const repo =
   window.location.pathname.split('/')[1] ||
   'holiday-adventures';
 
-const root = document.documentElement;
-const themeToggle = document.getElementById('theme-toggle');
-const storedTheme = localStorage.getItem('theme');
-const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-const currentTheme = storedTheme || (prefersDark ? 'dark' : 'light');
-root.setAttribute('data-theme', currentTheme);
-if (themeToggle) {
-  themeToggle.textContent = currentTheme === 'dark' ? '☀️' : '🌙';
-  themeToggle.addEventListener('click', () => {
-    const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-    root.setAttribute('data-theme', next);
-    localStorage.setItem('theme', next);
-    themeToggle.textContent = next === 'dark' ? '☀️' : '🌙';
+function initTheme() {
+  const root = document.documentElement;
+  const themeToggle = document.getElementById('theme-toggle');
+  const storedTheme = localStorage.getItem('theme');
+  const media = window.matchMedia('(prefers-color-scheme: dark)');
+  const currentTheme = storedTheme || (media.matches ? 'dark' : 'light');
+
+  root.setAttribute('data-theme', currentTheme);
+
+  const updateToggle = theme => {
+    if (themeToggle) {
+      themeToggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+    }
+  };
+
+  updateToggle(currentTheme);
+
+  media.addEventListener('change', e => {
+    if (!localStorage.getItem('theme')) {
+      const newTheme = e.matches ? 'dark' : 'light';
+      root.setAttribute('data-theme', newTheme);
+      updateToggle(newTheme);
+    }
   });
+
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      root.setAttribute('data-theme', next);
+      localStorage.setItem('theme', next);
+      updateToggle(next);
+    });
+  }
 }
+
+document.addEventListener('DOMContentLoaded', initTheme);
 
 function getHolidayToken() {
   return localStorage.getItem('HOLIDAY_TOKEN') || '';


### PR DESCRIPTION
## Summary
- defer theme setup until DOMContentLoaded
- add matchMedia listener to track system theme changes
- persist manual theme overrides in localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892542f97d08328a4be98c1c3c20587