### PR TITLE
Use color-text variable for theme toggle

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -365,5 +365,5 @@ button:focus {
   min-height: auto;
   font-size: 1.5rem;
   cursor: pointer;
-  color: var(--text);
+  color: var(--color-text);
 }


### PR DESCRIPTION
## Summary
- fix theme toggle button text color by using the shared `--color-text` variable

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892543f6a748328bb2089cbd7184dbc