### PR TITLE
Include projects directory in Holiday Bits

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -195,7 +195,8 @@ async function loadHolidayBits(headers) {
     { path: 'destinations', title: 'Destinations' },
     { path: 'ideas', title: 'Ideas' },
     { path: 'packing-lists', title: 'Packing Lists' },
-    { path: 'itinerary-templates', title: 'Itinerary Templates' }
+    { path: 'itinerary-templates', title: 'Itinerary Templates' },
+    { path: 'projects', title: 'Projects' }
   ];
   for (const { path, title } of sections) {
     try {


### PR DESCRIPTION
## Summary
- include `projects/` directory when rendering Holiday Bits

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892546156dc8328bde5c1fabc409268