### PR TITLE
feat: support classic and fine-grained tokens

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -240,7 +240,12 @@ async function loadHolidayBits(headers) {
 
 function loadData() {
   const token = getHolidayToken();
-  const headers = token ? { Authorization: `token ${token}` } : {};
+  let headers = {};
+  if (token) {
+    // Fine-grained PATs start with `github_pat_`; otherwise assume classic PAT
+    const isFineGrained = token.startsWith('github_pat_');
+    headers = { Authorization: `${isFineGrained ? 'Bearer' : 'token'} ${token}` };
+  }
   loadTasks(headers);
   loadProjectBoard(headers);
   loadHolidayBits(headers);


### PR DESCRIPTION
## Summary
- Detect whether stored token is a classic or fine-grained PAT
- Use `Bearer` auth for fine-grained tokens and `token` auth for classic tokens

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68925465e2f883289585a496d6799bae