### PR TITLE
feat: animate hero and navigation

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -23,6 +23,10 @@ const repo =
   window.location.pathname.split('/')[1] ||
   'holiday-adventures';
 
+function prefersReducedMotion() {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
 function initTheme() {
   const root = document.documentElement;
   const themeToggle = document.getElementById('theme-toggle');
@@ -290,6 +294,55 @@ function updateActiveNav() {
   links.forEach(link => link.classList.toggle('active', link === activeLink));
 }
 
+function startHeroSlideshow() {
+  const slides = document.querySelectorAll('.hero-slideshow img');
+  if (!slides.length) return;
+  let index = 0;
+  slides[index].classList.add('active');
+  if (prefersReducedMotion() || slides.length === 1) return;
+  setInterval(() => {
+    slides[index].classList.remove('active');
+    index = (index + 1) % slides.length;
+    slides[index].classList.add('active');
+  }, 5000);
+}
+
+function initAnimations() {
+  if (!prefersReducedMotion() && window.gsap) {
+    gsap.from('.main-nav a', { y: -20, opacity: 0, duration: 0.6, stagger: 0.1, ease: 'power2.out' });
+    gsap.from('.hero-tagline', { y: 50, opacity: 0, duration: 1, ease: 'power2.out' });
+  }
+  startHeroSlideshow();
+}
+
+function handleHeroScroll() {
+  if (prefersReducedMotion() || !window.gsap) return;
+  const tagline = document.querySelector('.hero-tagline');
+  if (!tagline) return;
+  const offset = Math.min(window.scrollY, 200);
+  gsap.to(tagline, { y: offset * 0.2, opacity: 1 - offset / 200, overwrite: 'auto', duration: 0.3 });
+}
+
+function initSectionObserver() {
+  if (!('IntersectionObserver' in window)) return;
+  const sections = document.querySelectorAll('section');
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('section-visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  sections.forEach(sec => {
+    if (!sec.classList.contains('hero')) {
+      sec.classList.add('section-hidden');
+      observer.observe(sec);
+    }
+  });
+}
+
 const saveBtn = document.getElementById('save-token');
 if (saveBtn) {
   saveBtn.addEventListener('click', () => {
@@ -339,5 +392,10 @@ if (taskForm) {
 document.addEventListener('DOMContentLoaded', () => {
   loadData();
   updateActiveNav();
+  initAnimations();
+  initSectionObserver();
 });
-window.addEventListener('scroll', updateActiveNav);
+window.addEventListener('scroll', () => {
+  updateActiveNav();
+  handleHeroScroll();
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,11 +22,11 @@
   </nav>
 
   <section class="hero">
-    <img
-      class="hero-image"
-      src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=1600&h=600&q=80"
-      alt="Scenic adventure"
-    />
+    <div class="hero-slideshow">
+      <img src="https://images.unsplash.com/photo-1502082553048-f009c37129b9?auto=format&fit=crop&w=1600&h=600&q=80" alt="Sunny desert" />
+      <img src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1600&h=600&q=80" alt="Ocean waves" />
+      <img src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=1600&h=600&q=80" alt="Forest trail" />
+    </div>
     <div class="hero-tagline">Your next adventure starts here</div>
   </section>
 
@@ -72,6 +72,7 @@
     </section>
   </div>
 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" integrity="sha512-5keOAkznBWCG2lLBVmOAXoJ2i8LojRxurx8WcN6i/K3PaY5E9O+V1YxAECEV4VpWw2X2gYdEx+kt1/3uzMdKug==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -148,6 +148,23 @@ section:nth-of-type(even) {
   background: var(--section-bg-even);
 }
 
+.section-hidden {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.section-visible {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .section-visible {
+    transition: none;
+  }
+}
+
 .section-image {
   width: 100%;
   max-width: 400px;
@@ -193,14 +210,31 @@ h2::before {
 .hero {
   display: grid;
   margin-bottom: 2rem;
+  position: relative;
+  height: 40vh;
 }
 
-.hero-image {
-  width: 100%;
-  height: 40vh;
-  object-fit: cover;
+.hero-slideshow {
   grid-area: 1 / 1;
-  animation: fade-in 1.5s ease-in-out;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-slideshow img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 1s ease-in-out;
+}
+
+.hero-slideshow img.active {
+  opacity: 1;
 }
 
 .hero-tagline {
@@ -210,16 +244,19 @@ h2::before {
   background: var(--hero-tagline-bg);
   padding: 1rem;
   border-radius: 8px;
+  will-change: transform, opacity;
+  z-index: 1;
 }
 
-@keyframes fade-in {
-  from {
-    opacity: 0;
-    transform: scale(1.05);
+@media (max-width: 600px) {
+  .hero {
+    height: 30vh;
   }
-  to {
-    opacity: 1;
-    transform: scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-slideshow img {
+    transition: none;
   }
 }
 
@@ -248,6 +285,7 @@ h2::before {
   min-height: 44px;      /* from main */
   text-align: center;    /* from main */
   transition: background-color 0.3s, color 0.3s, transform 0.2s; /* from main */
+  will-change: transform, opacity;
 }
 
 .main-nav a:hover {


### PR DESCRIPTION
## Summary
- replace hero image with slideshow and load GSAP for animations
- add responsive styles and scroll-triggered section reveal animations
- animate navigation links and hero tagline with GSAP and IntersectionObserver

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx playwright test playwright.spec.js --browser=chromium` *(fails: Cannot find module '@playwright/test')*


------
https://chatgpt.com/codex/tasks/task_e_689257c506d48328b7d8ee5971452d64