### PR TITLE
Use templated owner in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="repo" content="holiday-adventures" />
-  <meta name="owner" content="YOUR_GH_USER" />
+  <meta name="owner" content="{{GITHUB_OWNER}}" />
   <title>Adventure Holiday's Tracker</title>
   <link rel="stylesheet" href="styles.css" />
 </head>


### PR DESCRIPTION
## Summary
- Use `{{GITHUB_OWNER}}` placeholder for owner meta tag in static docs page

## Testing
- `python3 -m http.server --directory docs 8000 & curl -s http://localhost:8000/index.html | head -n 10`
- `node <<'NODE'
const { JSDOM } = require('jsdom');
const fs = require('fs');

const html = fs.readFileSync('docs/index.html', 'utf8');
const dom = new JSDOM(html, { url: 'https://example.com' });
const window = dom.window;
window.env = { GITHUB_OWNER: 'octocat' };
window.matchMedia = () => ({ matches:false, addEventListener(){}, removeEventListener(){}});
global.window = window;
global.document = window.document;
global.localStorage = { getItem: () => null, setItem: () => {} };
global.fetch = (url, opts) => { console.log('fetch called with', url); return Promise.resolve({ ok: false, json: async () => [] }); };

const script = fs.readFileSync('docs/app.js', 'utf8');
require('vm').runInThisContext(script);

async function main() {
  await loadTasks({});
}
main();
NODE
`

------
https://chatgpt.com/codex/tasks/task_e_689258aa1e688328b4b537135abaa377