### PR TITLE
Add configurable GitHub token loading

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -2,6 +2,7 @@
 // Allow overrides via query parameters (e.g., ?owner=user&repo=project),
 // a global config object `window.HOLIDAY_CONFIG`, or environment variables
 // exposed on `window.ENV`. Falls back to parsing the current URL.
+import { GITHUB_TOKEN } from './config.js';
 const queryParams = new URLSearchParams(window.location.search);
 const globalConfig = window.HOLIDAY_CONFIG || {};
 const envConfig = (typeof window !== 'undefined' && (window.ENV || window.env)) || {};
@@ -58,7 +59,7 @@ function initTheme() {
 document.addEventListener('DOMContentLoaded', initTheme);
 
 function getHolidayToken() {
-  return localStorage.getItem('HOLIDAY_TOKEN') || '';
+  return GITHUB_TOKEN || localStorage.getItem('HOLIDAY_TOKEN') || '';
 }
 
 async function loadTasks(headers) {

--- a/docs/config.js
+++ b/docs/config.js
@@ -1,0 +1,3 @@
+// GitHub personal access token; leave empty to use localStorage or user input
+export const GITHUB_TOKEN = '';
+export default GITHUB_TOKEN;

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,6 +79,6 @@
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" integrity="sha512-5keOAkznBWCG2lLBVmOAXoJ2i8LojRxurx8WcN6i/K3PaY5E9O+V1YxAECEV4VpWw2X2gYdEx+kt1/3uzMdKug==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `docs/config.js` to export a GitHub token constant
- load token from config in `docs/app.js` with localStorage fallback
- treat `docs/app.js` as an ES module so imports work

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892605ab5c883288c96ce591b6eb07f