### PR TITLE
feat: add itinerary timeline and memory form

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -259,6 +259,73 @@ async function loadHolidayBits(headers) {
   }
 }
 
+async function loadItinerary(headers) {
+  const timelineEl = document.getElementById('itinerary-timeline');
+  if (!timelineEl) return;
+  timelineEl.innerHTML = '';
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/issues?labels=itinerary&per_page=100`,
+      { headers }
+    );
+    if (!res.ok) {
+      timelineEl.textContent = 'No itinerary entries found.';
+      return;
+    }
+    const items = await res.json();
+    items.forEach(issue => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'itinerary-item';
+      let data = {};
+      try {
+        data = issue.body ? JSON.parse(issue.body) : {};
+      } catch (_) {
+        data = {};
+      }
+      const title = document.createElement('h3');
+      title.textContent = issue.title;
+      wrapper.appendChild(title);
+      if (data.photo) {
+        const img = document.createElement('img');
+        img.src = data.photo;
+        img.alt = issue.title;
+        img.loading = 'lazy';
+        wrapper.appendChild(img);
+      }
+      const fields = [
+        ['Activities', data.activities],
+        ['Budget', data.budget],
+        ['Notes', data.notes]
+      ];
+      fields.forEach(([label, val]) => {
+        if (val) {
+          const p = document.createElement('p');
+          p.innerHTML = `<strong>${label}:</strong> ${val}`;
+          wrapper.appendChild(p);
+        }
+      });
+      const editBtn = document.createElement('button');
+      editBtn.textContent = 'Edit';
+      editBtn.addEventListener('click', () => {
+        const form = document.getElementById('itinerary-form');
+        if (!form) return;
+        document.getElementById('itinerary-issue-number').value = issue.number;
+        document.getElementById('itinerary-destination').value = issue.title;
+        document.getElementById('itinerary-activities').value = data.activities || '';
+        document.getElementById('itinerary-budget').value = data.budget || '';
+        document.getElementById('itinerary-photo').value = data.photo || '';
+        document.getElementById('itinerary-notes').value = data.notes || '';
+        form.scrollIntoView({ behavior: 'smooth' });
+      });
+      wrapper.appendChild(editBtn);
+      timelineEl.appendChild(wrapper);
+    });
+  } catch (err) {
+    timelineEl.textContent = 'Unable to load itinerary.';
+    console.error('loadItinerary:', err && err.message ? err.message : err);
+  }
+}
+
   function loadData() {
     if (!owner) {
       console.warn('GitHub owner could not be determined. Please configure it.');
@@ -282,6 +349,7 @@ async function loadHolidayBits(headers) {
     loadTasks(headers);
     loadProjectBoard(headers);
     loadHolidayBits(headers);
+    loadItinerary(headers);
   }
 
 function updateActiveNav() {
@@ -385,6 +453,49 @@ if (taskForm) {
       const data = await res.json();
       resultEl.innerHTML = `Task created: <a href="${data.html_url}" target="_blank">${data.number}</a>`;
       taskForm.reset();
+      loadData();
+    } else {
+      const err = await res.json();
+      resultEl.textContent = `Error: ${err.message}`;
+    }
+  });
+}
+
+const itineraryForm = document.getElementById('itinerary-form');
+if (itineraryForm) {
+  itineraryForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const token = getHolidayToken();
+    if (!token) {
+      alert('Please save a token first.');
+      return;
+    }
+    const number = document.getElementById('itinerary-issue-number').value.trim();
+    const destination = document.getElementById('itinerary-destination').value;
+    const activities = document.getElementById('itinerary-activities').value;
+    const budget = document.getElementById('itinerary-budget').value;
+    const photo = document.getElementById('itinerary-photo').value;
+    const notes = document.getElementById('itinerary-notes').value;
+    const bodyObj = { activities, budget, photo, notes };
+    const url = `https://api.github.com/repos/${owner}/${repo}/issues${number ? '/' + number : ''}`;
+    const method = number ? 'PATCH' : 'POST';
+    const payload = number
+      ? { title: destination, body: JSON.stringify(bodyObj, null, 2) }
+      : { title: destination, body: JSON.stringify(bodyObj, null, 2), labels: ['itinerary'] };
+    const res = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `token ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+    const resultEl = document.getElementById('itinerary-result');
+    if (res.ok) {
+      const data = await res.json();
+      resultEl.innerHTML = `Entry saved: <a href="${data.html_url}" target="_blank">#${data.number}</a>`;
+      itineraryForm.reset();
+      document.getElementById('itinerary-issue-number').value = '';
       loadData();
     } else {
       const err = await res.json();

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,6 +25,7 @@
     <a href="#tasks"><span class="nav-icon">📝</span>Tasks</a>
     <a href="#project-board"><span class="nav-icon">📋</span>Project Board</a>
     <a href="#holiday-bits"><span class="nav-icon">🎒</span>Holiday Bits</a>
+    <a href="#itinerary"><span class="nav-icon">🗺️</span>Itinerary</a>
   </nav>
 
   <section class="hero">
@@ -62,6 +63,28 @@
       <h2>Travel Bits</h2>
       <img src="https://source.unsplash.com/400x200/?travel" alt="Travel items" class="section-image" loading="lazy" />
       <div id="holiday-bits-container"></div>
+    </section>
+
+    <section id="itinerary">
+      <h2>Itinerary &amp; Memories</h2>
+      <img src="https://source.unsplash.com/400x200/?map" alt="Itinerary map" class="section-image" loading="lazy" />
+      <div id="itinerary-timeline"></div>
+      <h3>Add or Update Entry</h3>
+      <form id="itinerary-form">
+        <input type="hidden" id="itinerary-issue-number" />
+        <label for="itinerary-destination">Destination</label>
+        <input type="text" id="itinerary-destination" required />
+        <label for="itinerary-activities">Activities</label>
+        <textarea id="itinerary-activities"></textarea>
+        <label for="itinerary-budget">Budget</label>
+        <input type="text" id="itinerary-budget" />
+        <label for="itinerary-photo">Photo URL</label>
+        <input type="url" id="itinerary-photo" />
+        <label for="itinerary-notes">Notes</label>
+        <textarea id="itinerary-notes"></textarea>
+        <button type="submit">Save Entry</button>
+      </form>
+      <div id="itinerary-result"></div>
     </section>
 
     <section id="new-task">


### PR DESCRIPTION
## Summary
- add itinerary navigation and timeline section with destination, activities, budget, photo, and notes fields
- support loading, creating, and updating itinerary entries via GitHub issues

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689260593f348328adfcad03ae11b8b6