### PR TITLE
feat: add project selection for MadGodNerevar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -22,6 +22,7 @@
     </header>
 
   <nav class="main-nav">
+    <a href="#projects"><span class="nav-icon">📁</span>Projects</a>
     <a href="#tasks"><span class="nav-icon">📝</span>Tasks</a>
     <a href="#project-board"><span class="nav-icon">📋</span>Project Board</a>
     <a href="#holiday-bits"><span class="nav-icon">🎒</span>Holiday Bits</a>
@@ -44,6 +45,17 @@
       <label for="token-input">Personal Access Token</label>
       <input type="password" id="token-input" placeholder="HOLIDAY_TOKEN" />
       <button id="save-token">Save Token</button>
+    </section>
+
+    <section id="projects">
+      <h2>Projects</h2>
+      <label for="project-selector">Choose a project</label>
+      <select id="project-selector"></select>
+      <p id="project-description"></p>
+      <h3>Milestones</h3>
+      <ul id="project-milestones"></ul>
+      <h3>Issues</h3>
+      <ul id="project-issues"></ul>
     </section>
 
     <section id="tasks">


### PR DESCRIPTION
## Summary
- Hardcode `MadGodNerevar` as the GitHub user and default project to `next-trip`.
- Populate a project selector from the user's repositories and load the selected project's description, milestones, and issues.
- Introduce navigation and UI for choosing and viewing project details.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68926056293c832897baec7e7d8411f4