### PR TITLE
Remove stray closing div in documentation index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -179,7 +179,6 @@
         </div>
       </div>
     </footer>
-  </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>


### PR DESCRIPTION
## Summary
- remove extraneous closing `div` after the footer in `docs/index.html`

## Testing
- `tidy -q -e docs/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689265ee5c808328b9a3f1b6e5c8aeca