### PR TITLE
Handle markdown in Holiday Bits

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -336,11 +336,16 @@ async function loadHolidayBits(headers) {
       files.forEach(file => {
         if (file.type === 'file') {
           const li = document.createElement('li');
-          const a = document.createElement('a');
-          a.href = file.html_url;
-          a.textContent = file.name;
-          a.target = '_blank';
-          li.appendChild(a);
+          const name = file.name.replace(/\.md$/, '').replace(/-/g, ' ');
+          if (file.name.endsWith('.md')) {
+            li.textContent = name;
+          } else {
+            const a = document.createElement('a');
+            a.href = file.html_url;
+            a.textContent = name;
+            a.target = '_blank';
+            li.appendChild(a);
+          }
           ul.appendChild(li);
         }
       });


### PR DESCRIPTION
## Summary
- Avoid linking Markdown files when listing repository contents
- Format file names for cleaner display

## Testing
- `node --check docs/app.js`
- `node - <<'NODE'\nfunction createElement(tag){return {tagName:tag.toUpperCase(),children:[],textContent:'',href:null,target:null,appendChild(child){this.children.push(child);}}}\nconst files=[{type:'file',name:'guide.md',html_url:'https://example.com/guide.md'},{type:'file',name:'photo.png',html_url:'https://example.com/photo.png'}];\nconst ul=createElement('ul');\nfiles.forEach(file=>{\n  if(file.type==='file'){\n    const li=createElement('li');\n    const name=file.name.replace(/\\.md$/,'').replace(/-/g,' ');\n    if(file.name.endsWith('.md')){\n      li.textContent=name;\n    } else {\n      const a=createElement('a');\n      a.href=file.html_url;\n      a.textContent=name;\n      a.target='_blank';\n      li.appendChild(a);\n    }\n    ul.appendChild(li);\n  }\n});\nconsole.log(JSON.stringify(ul,null,2));\nNODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68926a7931d88328b8ea8a84548cf6c1