### PR TITLE
Serve local images with fallback

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -517,6 +517,18 @@ function initAOS() {
   if (window.AOS) AOS.init();
 }
 
+function initImageFallback() {
+  const images = document.querySelectorAll('img');
+  images.forEach(img => {
+    img.addEventListener('error', () => {
+      if (!img.dataset.fallback) {
+        img.dataset.fallback = 'true';
+        img.src = 'assets/placeholder.svg';
+      }
+    });
+  });
+}
+
 const saveBtn = document.getElementById('save-token');
 if (saveBtn) {
   saveBtn.addEventListener('click', () => {
@@ -623,6 +635,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initSectionObserver();
   initPlanner();
   initAOS();
+  initImageFallback();
 });
 window.addEventListener('scroll', () => {
   updateActiveNav();

--- a/docs/assets/destination-newyork.svg
+++ b/docs/assets/destination-newyork.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">New York</text>
+</svg>

--- a/docs/assets/destination-paris.svg
+++ b/docs/assets/destination-paris.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Paris</text>
+</svg>

--- a/docs/assets/destination-tokyo.svg
+++ b/docs/assets/destination-tokyo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Tokyo</text>
+</svg>

--- a/docs/assets/hero-desert.svg
+++ b/docs/assets/hero-desert.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="600">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Hero Desert</text>
+</svg>

--- a/docs/assets/hero-forest.svg
+++ b/docs/assets/hero-forest.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="600">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Hero Forest</text>
+</svg>

--- a/docs/assets/hero-ocean.svg
+++ b/docs/assets/hero-ocean.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="600">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Hero Ocean</text>
+</svg>

--- a/docs/assets/lock.svg
+++ b/docs/assets/lock.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Secure</text>
+</svg>

--- a/docs/assets/map.svg
+++ b/docs/assets/map.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Map</text>
+</svg>

--- a/docs/assets/pencil.svg
+++ b/docs/assets/pencil.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Write</text>
+</svg>

--- a/docs/assets/placeholder.svg
+++ b/docs/assets/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Image Unavailable</text>
+</svg>

--- a/docs/assets/planning.svg
+++ b/docs/assets/planning.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Planning</text>
+</svg>

--- a/docs/assets/todo.svg
+++ b/docs/assets/todo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Checklist</text>
+</svg>

--- a/docs/assets/travel.svg
+++ b/docs/assets/travel.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
+  <rect width="100%" height="100%" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#555" font-size="24">Travel</text>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,9 +26,9 @@
 
     <section class="hero">
       <div class="hero-slideshow">
-        <img src="https://images.unsplash.com/photo-1502082553048-f009c37129b9?auto=format&fit=crop&w=1600&h=600&q=80" alt="Sunny desert" />
-        <img src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1600&h=600&q=80" alt="Ocean waves" />
-        <img src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=1600&h=600&q=80" alt="Forest trail" />
+        <img src="assets/hero-desert.svg" alt="Sunny desert" referrerpolicy="no-referrer" />
+        <img src="assets/hero-ocean.svg" alt="Ocean waves" referrerpolicy="no-referrer" />
+        <img src="assets/hero-forest.svg" alt="Forest trail" referrerpolicy="no-referrer" />
       </div>
       <div class="hero-tagline" data-aos="zoom-in">
         Your next adventure starts here
@@ -80,15 +80,15 @@
       <h2>Destination Highlights</h2>
       <div class="destinations-grid">
         <div class="destination" data-aos="zoom-in">
-          <img src="https://source.unsplash.com/300x200/?paris" alt="Paris" />
+          <img src="assets/destination-paris.svg" alt="Paris" referrerpolicy="no-referrer" />
           <h3>Paris</h3>
         </div>
         <div class="destination" data-aos="zoom-in">
-          <img src="https://source.unsplash.com/300x200/?tokyo" alt="Tokyo" />
+          <img src="assets/destination-tokyo.svg" alt="Tokyo" referrerpolicy="no-referrer" />
           <h3>Tokyo</h3>
         </div>
         <div class="destination" data-aos="zoom-in">
-          <img src="https://source.unsplash.com/300x200/?newyork" alt="New York" />
+          <img src="assets/destination-newyork.svg" alt="New York" referrerpolicy="no-referrer" />
           <h3>New York</h3>
         </div>
       </div>
@@ -97,7 +97,7 @@
     <div class="container">
       <section id="token">
         <h2>Authentication</h2>
-        <img src="https://source.unsplash.com/400x200/?lock" alt="Secure lock" class="section-image" loading="lazy" />
+        <img src="assets/lock.svg" alt="Secure lock" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
         <p>Enter a GitHub personal access token with <code>repo</code> scope. The token is stored only in this browser as <code>HOLIDAY_TOKEN</code> in <code>localStorage</code>.</p>
         <label for="token-input">Personal Access Token</label>
         <input type="password" id="token-input" placeholder="HOLIDAY_TOKEN" />
@@ -117,25 +117,25 @@
 
       <section id="tasks">
         <h2>Tasks</h2>
-        <img src="https://source.unsplash.com/400x200/?todo" alt="Checklist" class="section-image" loading="lazy" />
+        <img src="assets/todo.svg" alt="Checklist" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
         <ul id="tasks-list"></ul>
       </section>
 
       <section id="project-board">
         <h2>Project Board</h2>
-        <img src="https://source.unsplash.com/400x200/?planning" alt="Project planning board" class="section-image" loading="lazy" />
+        <img src="assets/planning.svg" alt="Project planning board" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
         <div id="project-columns"></div>
       </section>
 
       <section id="holiday-bits">
         <h2>Travel Bits</h2>
-        <img src="https://source.unsplash.com/400x200/?travel" alt="Travel items" class="section-image" loading="lazy" />
+        <img src="assets/travel.svg" alt="Travel items" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
         <div id="holiday-bits-container"></div>
       </section>
 
       <section id="itinerary">
         <h2>Itinerary &amp; Memories</h2>
-        <img src="https://source.unsplash.com/400x200/?map" alt="Itinerary map" class="section-image" loading="lazy" />
+        <img src="assets/map.svg" alt="Itinerary map" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
         <div id="itinerary-timeline"></div>
         <h3>Add or Update Entry</h3>
         <form id="itinerary-form">
@@ -157,7 +157,7 @@
 
       <section id="new-task">
         <h2>Submit a New Task</h2>
-        <img src="https://source.unsplash.com/400x200/?pencil" alt="Writing a new task" class="section-image" loading="lazy" />
+        <img src="assets/pencil.svg" alt="Writing a new task" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
         <form id="task-form">
           <label for="task-title">Title</label>
           <input type="text" id="task-title" required />


### PR DESCRIPTION
## Summary
- replace remote Unsplash image sources with local `docs/assets` placeholders and add `referrerpolicy="no-referrer"`
- introduce `initImageFallback` to swap in a placeholder when an image fails to load
- generate local SVG assets for hero, destination, and section images

## Testing
- `npm test` *(fails: package.json missing)*
- `python3 -m http.server` & `curl -I http://localhost:8000/assets/hero-desert.svg`


------
https://chatgpt.com/codex/tasks/task_e_68926c3a645c8328975b08769507e716