### PR TITLE
fix: remove project selector and hardcode repo

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -10,13 +10,7 @@ const envConfig = (typeof window !== 'undefined' && (window.ENV || window.env)) 
 const username = 'MadGodNerevar';
 const owner = username;
 
-const repoMeta = document.querySelector('meta[name="repo"]');
-let repo =
-  queryParams.get('repo') ||
-  globalConfig.repo ||
-  envConfig.GITHUB_REPO ||
-  (repoMeta ? repoMeta.getAttribute('content') : null) ||
-  'next-trip';
+const repo = 'holiday-adventures';
 
 // Access key for Unsplash API (required for destination images)
 const unsplashAccessKey =
@@ -58,26 +52,6 @@ function initTheme() {
 
 function getHolidayToken() {
   return GITHUB_TOKEN || localStorage.getItem('HOLIDAY_TOKEN') || '';
-}
-
-async function loadUserProjects() {
-  const selector = document.getElementById('project-selector');
-  if (!selector) return;
-  try {
-    const res = await fetch(`https://api.github.com/users/${owner}/repos`);
-    if (!res.ok) throw new Error('Failed to load repositories');
-    const projects = await res.json();
-    selector.innerHTML = '';
-    projects.forEach(p => {
-      const option = document.createElement('option');
-      option.value = p.name;
-      option.textContent = p.name.replace(/-/g, ' ');
-      selector.appendChild(option);
-    });
-    selector.value = repo;
-  } catch (err) {
-    console.error('loadUserProjects:', err);
-  }
 }
 
 async function loadProjectDetails(project) {
@@ -530,14 +504,6 @@ if (saveBtn) {
   });
 }
 
-const projectSelector = document.getElementById('project-selector');
-if (projectSelector) {
-  projectSelector.addEventListener('change', e => {
-    repo = e.target.value || 'next-trip';
-    loadProjectDetails(repo);
-    loadData();
-  });
-}
 
 const taskForm = document.getElementById('task-form');
 if (taskForm) {
@@ -616,7 +582,7 @@ if (itineraryForm) {
 
 // Initial load
 document.addEventListener('DOMContentLoaded', () => {
-  loadUserProjects().then(() => loadProjectDetails(repo));
+  loadProjectDetails('holiday-adventures');
   loadData();
   updateActiveNav();
   initAnimations();

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,13 +39,6 @@
       </div>
     </section>
 
-    <section id="project-selector" data-aos="fade-up">
-      <h2>Project Selector</h2>
-      <select id="project-select" aria-label="Select project">
-        <option value="">Loading projects...</option>
-      </select>
-    </section>
-
     <section id="planner" data-aos="fade-up">
       <h2>Interactive Planner</h2>
       <div class="progress-wrapper">
@@ -106,8 +99,6 @@
 
       <section id="projects">
         <h2>Projects</h2>
-        <label for="project-selector">Choose a project</label>
-        <select id="project-selector"></select>
         <p id="project-description"></p>
         <h3>Milestones</h3>
         <ul id="project-milestones"></ul>


### PR DESCRIPTION
## Summary
- fix app to always load `holiday-adventures` repository and remove project selector dropdown
- delete unused project-selector section from docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68926ced05348328a06e3c384950bfbc