### PR TITLE
chore: modernize docs layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,11 +25,7 @@
     </nav>
 
     <section class="hero">
-      <div class="hero-slideshow">
-        <img src="https://images.unsplash.com/photo-1502082553048-f009c37129b9?auto=format&fit=crop&w=1600&h=600&q=80" alt="Sunny desert" />
-        <img src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1600&h=600&q=80" alt="Ocean waves" />
-        <img src="https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=1600&h=600&q=80" alt="Forest trail" />
-      </div>
+      <img src="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1600&h=600&q=80" alt="Ocean waves" class="hero-image" />
       <div class="hero-tagline" data-aos="zoom-in">
         Your next adventure starts here
         <div class="hero-cta">
@@ -39,63 +35,79 @@
       </div>
     </section>
 
-    <section id="project-selector" data-aos="fade-up">
-      <h2>Project Selector</h2>
-      <select id="project-select" aria-label="Select project">
-        <option value="">Loading projects...</option>
-      </select>
-    </section>
+    <main class="container">
+      <section id="project-selector" class="card" data-aos="fade-up">
+        <h2>Project Selector</h2>
+        <select id="project-select" aria-label="Select project">
+          <option value="">Loading projects...</option>
+        </select>
+      </section>
 
-    <section id="planner" data-aos="fade-up">
-      <h2>Interactive Planner</h2>
-      <div class="progress-wrapper">
-        <div id="planner-progress"></div>
+      <section id="planner" class="card" data-aos="fade-up">
+        <h2>Interactive Planner</h2>
+        <div class="progress-wrapper">
+          <div id="planner-progress"></div>
+        </div>
+        <ul id="planner-tasks">
+          <li><label><input type="checkbox" /> Book flights</label></li>
+          <li><label><input type="checkbox" /> Reserve hotels</label></li>
+          <li><label><input type="checkbox" /> Pack bags</label></li>
+        </ul>
+      </section>
+
+      <div class="dashboard-grid">
+        <section id="timeline" class="card" data-aos="fade-up">
+          <h2>Itinerary &amp; Memories</h2>
+          <div class="timeline">
+            <div class="timeline-item" data-aos="fade-up">
+              <span class="timeline-date">Day 1</span>
+              <p>Arrive at destination and explore the city.</p>
+            </div>
+            <div class="timeline-item" data-aos="fade-up">
+              <span class="timeline-date">Day 2</span>
+              <p>Adventure tour with friends.</p>
+            </div>
+            <div class="timeline-item" data-aos="fade-up">
+              <span class="timeline-date">Day 3</span>
+              <p>Relax and capture memories.</p>
+            </div>
+          </div>
+        </section>
+
+        <div class="widgets">
+          <section id="tasks" class="card">
+            <h2>Tasks</h2>
+            <img src="https://source.unsplash.com/400x200/?todo" alt="Checklist" class="section-image" loading="lazy" />
+            <ul id="tasks-list"></ul>
+          </section>
+
+          <section id="project-board" class="card">
+            <h2>Project Board</h2>
+            <img src="https://source.unsplash.com/400x200/?planning" alt="Project planning board" class="section-image" loading="lazy" />
+            <div id="project-columns"></div>
+          </section>
+        </div>
       </div>
-      <ul id="planner-tasks">
-        <li><label><input type="checkbox" /> Book flights</label></li>
-        <li><label><input type="checkbox" /> Reserve hotels</label></li>
-        <li><label><input type="checkbox" /> Pack bags</label></li>
-      </ul>
-    </section>
 
-    <section id="timeline" data-aos="fade-up">
-      <h2>Itinerary &amp; Memories</h2>
-      <div class="timeline">
-        <div class="timeline-item" data-aos="fade-up">
-          <span class="timeline-date">Day 1</span>
-          <p>Arrive at destination and explore the city.</p>
+      <section id="destinations" class="card" data-aos="fade-up">
+        <h2>Destination Highlights</h2>
+        <div class="destinations-grid">
+          <div class="destination" data-aos="zoom-in">
+            <img src="https://source.unsplash.com/300x200/?paris" alt="Paris" />
+            <h3>Paris</h3>
+          </div>
+          <div class="destination" data-aos="zoom-in">
+            <img src="https://source.unsplash.com/300x200/?tokyo" alt="Tokyo" />
+            <h3>Tokyo</h3>
+          </div>
+          <div class="destination" data-aos="zoom-in">
+            <img src="https://source.unsplash.com/300x200/?newyork" alt="New York" />
+            <h3>New York</h3>
+          </div>
         </div>
-        <div class="timeline-item" data-aos="fade-up">
-          <span class="timeline-date">Day 2</span>
-          <p>Adventure tour with friends.</p>
-        </div>
-        <div class="timeline-item" data-aos="fade-up">
-          <span class="timeline-date">Day 3</span>
-          <p>Relax and capture memories.</p>
-        </div>
-      </div>
-    </section>
+      </section>
 
-    <section id="destinations" data-aos="fade-up">
-      <h2>Destination Highlights</h2>
-      <div class="destinations-grid">
-        <div class="destination" data-aos="zoom-in">
-          <img src="https://source.unsplash.com/300x200/?paris" alt="Paris" />
-          <h3>Paris</h3>
-        </div>
-        <div class="destination" data-aos="zoom-in">
-          <img src="https://source.unsplash.com/300x200/?tokyo" alt="Tokyo" />
-          <h3>Tokyo</h3>
-        </div>
-        <div class="destination" data-aos="zoom-in">
-          <img src="https://source.unsplash.com/300x200/?newyork" alt="New York" />
-          <h3>New York</h3>
-        </div>
-      </div>
-    </section>
-
-    <div class="container">
-      <section id="token">
+      <section id="token" class="card">
         <h2>Authentication</h2>
         <img src="https://source.unsplash.com/400x200/?lock" alt="Secure lock" class="section-image" loading="lazy" />
         <p>Enter a GitHub personal access token with <code>repo</code> scope. The token is stored only in this browser as <code>HOLIDAY_TOKEN</code> in <code>localStorage</code>.</p>
@@ -104,7 +116,7 @@
         <button id="save-token">Save Token</button>
       </section>
 
-      <section id="projects">
+      <section id="projects" class="card">
         <h2>Projects</h2>
         <label for="project-selector">Choose a project</label>
         <select id="project-selector"></select>
@@ -115,25 +127,13 @@
         <ul id="project-issues"></ul>
       </section>
 
-      <section id="tasks">
-        <h2>Tasks</h2>
-        <img src="https://source.unsplash.com/400x200/?todo" alt="Checklist" class="section-image" loading="lazy" />
-        <ul id="tasks-list"></ul>
-      </section>
-
-      <section id="project-board">
-        <h2>Project Board</h2>
-        <img src="https://source.unsplash.com/400x200/?planning" alt="Project planning board" class="section-image" loading="lazy" />
-        <div id="project-columns"></div>
-      </section>
-
-      <section id="holiday-bits">
+      <section id="holiday-bits" class="card">
         <h2>Travel Bits</h2>
         <img src="https://source.unsplash.com/400x200/?travel" alt="Travel items" class="section-image" loading="lazy" />
         <div id="holiday-bits-container"></div>
       </section>
 
-      <section id="itinerary">
+      <section id="itinerary" class="card">
         <h2>Itinerary &amp; Memories</h2>
         <img src="https://source.unsplash.com/400x200/?map" alt="Itinerary map" class="section-image" loading="lazy" />
         <div id="itinerary-timeline"></div>
@@ -155,7 +155,7 @@
         <div id="itinerary-result"></div>
       </section>
 
-      <section id="new-task">
+      <section id="new-task" class="card">
         <h2>Submit a New Task</h2>
         <img src="https://source.unsplash.com/400x200/?pencil" alt="Writing a new task" class="section-image" loading="lazy" />
         <form id="task-form">
@@ -167,7 +167,7 @@
         </form>
         <div id="task-result"></div>
       </section>
-    </div>
+    </main>
 
     <footer class="site-footer">
       <div class="footer-content">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -62,6 +62,12 @@ body {
   font-size: var(--font-size-base);
 }
 
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--space-lg);
+}
+
 h1, h2, h3 {
   font-family: 'Poppins', sans-serif;
   margin-top: 0;
@@ -168,40 +174,25 @@ h2::before {
   content: '📸';
 }
 
-.hero {
+ .hero {
   position: relative;
-  display: grid;
-  place-items: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin-bottom: var(--space-xl);
   height: 60vh;
   text-align: center;
   color: #fff;
-  background: linear-gradient(-45deg, var(--teal), var(--coral), var(--sunset), var(--teal));
-  background-size: 400% 400%;
   overflow: hidden;
 }
 
-.hero-slideshow {
-  grid-area: 1 / 1;
-  width: 100%;
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
-
-.hero-slideshow img {
+.hero-image {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
-  opacity: 0;
-  transition: opacity 1s ease-in-out;
-}
-
-.hero-slideshow img.active {
-  opacity: 1;
 }
 
 .hero-tagline {
@@ -220,12 +211,6 @@ h2::before {
 @media (max-width: 600px) {
   .hero {
     height: 30vh;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .hero-slideshow img {
-    transition: none;
   }
 }
 
@@ -261,18 +246,11 @@ h2::before {
   50% { transform: translateY(-15px); }
 }
 
-.cards {
-  display: grid;
-  gap: var(--space-lg);
-  padding: var(--space-xl);
-}
-
 .card {
   background: var(--card-bg);
-  border-radius: 15px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  box-shadow: 0 2px 6px var(--section-shadow);
   padding: var(--space-lg);
-  transition: transform 0.3s;
 }
 
 .section-image {
@@ -296,8 +274,25 @@ button:hover {
 }
 
 @media (min-width: 768px) {
-  .cards {
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  .dashboard-grid {
+    grid-template-columns: 2fr 1fr;
+  }
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.widgets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+@media (max-width: 767px) {
+  .dashboard-grid {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace gradient hero with clean image
- center content and arrange timeline vs. widgets in responsive grid
- apply card styling for consistent spacing and shadows

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m http.server` served site; fetched `/docs/index.html` with desktop and mobile user agents

------
https://chatgpt.com/codex/tasks/task_e_68926ce84f5c8328aed32422d80e7ee8