### PR TITLE
Add hero slideshow crossfade

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -580,6 +580,19 @@ function handleHeroScroll() {
   gsap.to(tagline, { y: offset * 0.2, opacity: 1 - offset / 200, overwrite: 'auto', duration: 0.3 });
 }
 
+function initHeroSlideshow() {
+  if (prefersReducedMotion()) return;
+  const slides = document.querySelectorAll('.hero-slideshow img');
+  if (!slides.length) return;
+  let current = 0;
+  setInterval(() => {
+    const next = (current + 1) % slides.length;
+    slides[current].style.opacity = 0;
+    slides[next].style.opacity = 1;
+    current = next;
+  }, 5000);
+}
+
 function initSectionObserver() {
   if (!('IntersectionObserver' in window)) return;
   const sections = document.querySelectorAll('section');
@@ -737,6 +750,7 @@ document.addEventListener('DOMContentLoaded', () => {
   loadData();
   updateActiveNav();
   initAnimations();
+  initHeroSlideshow();
   initSectionObserver();
   initPlanner();
   initAOS();

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
     </nav>
 
     <section class="hero">
-      <div class="hero-slideshow">
+      <div class="hero-slideshow" aria-label="Slideshow of scenic destinations">
         <img src="assets/hero-desert.svg" alt="Sunny desert" referrerpolicy="no-referrer" />
         <img src="assets/hero-ocean.svg" alt="Ocean waves" referrerpolicy="no-referrer" />
         <img src="assets/hero-forest.svg" alt="Forest trail" referrerpolicy="no-referrer" />

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -200,7 +200,7 @@ h2::before {
   content: '📸';
 }
 
- .hero {
+.hero {
   position: relative;
   display: flex;
   align-items: center;
@@ -212,13 +212,28 @@ h2::before {
   overflow: hidden;
 }
 
-.hero-image {
+.hero-slideshow {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+}
+
+.hero-slideshow img {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
+  opacity: 0;
+  transition: opacity 1s ease-in-out;
+}
+
+.hero-slideshow img:first-child {
+  opacity: 1;
 }
 
 .hero-tagline {


### PR DESCRIPTION
## Summary
- Add accessible hero slideshow with crossfading images
- Include JS-driven fade rotation and respect reduced motion
- Style slideshow images with absolute positioning and fade transitions

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx playwright screenshot docs/index.html /tmp/screenshot-desktop.png --viewport-size=1280,800`
- `npx playwright screenshot docs/index.html /tmp/screenshot-mobile.png --viewport-size=375,667`


------
https://chatgpt.com/codex/tasks/task_e_68927162c750832889a2ecb27df7ef2c