### PR TITLE
feat: add dashboard grid layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -94,48 +94,52 @@
         <ul id="project-issues"></ul>
       </section>
 
-      <section id="tasks">
-        <h2>Tasks</h2>
-        <img src="assets/todo.svg" alt="Checklist" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
-        <ul id="tasks-list"></ul>
-      </section>
-
-      <section id="project-board">
-        <h2>Project Board</h2>
-        <img src="assets/planning.svg" alt="Project planning board" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
-        <div id="project-columns"></div>
-      </section>
-
       <section id="holiday-bits">
         <h2>Travel Bits</h2>
         <img src="assets/travel.svg" alt="Travel items" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
         <div id="holiday-bits-container"></div>
       </section>
 
-      <section id="itinerary" class="card">
-        <h2>Itinerary &amp; Memories</h2>
-        <img src="assets/map.svg" alt="Itinerary map" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
-        <ul id="itinerary-list"></ul>
-        <div id="itinerary-map" style="height: 300px;"></div>
-        <h3>Add or Update Entry</h3>
-        <form id="itinerary-form">
-          <input type="hidden" id="itinerary-issue-number" />
-          <label for="itinerary-day">Day</label>
-          <input type="number" id="itinerary-day" min="1" required />
-          <label for="itinerary-destination">Destination</label>
-          <input type="text" id="itinerary-destination" required />
-          <label for="itinerary-activities">Activities</label>
-          <textarea id="itinerary-activities"></textarea>
-          <label for="itinerary-budget">Budget</label>
-          <input type="text" id="itinerary-budget" />
-          <label for="itinerary-photo">Photo URL</label>
-          <input type="url" id="itinerary-photo" />
-          <label for="itinerary-notes">Notes</label>
-          <textarea id="itinerary-notes"></textarea>
-          <button type="submit">Save Entry</button>
-        </form>
-        <div id="itinerary-result"></div>
-      </section>
+      <div class="dashboard-grid">
+        <section id="itinerary" class="card">
+          <h2>Itinerary &amp; Memories</h2>
+          <img src="assets/map.svg" alt="Itinerary map" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
+          <ul id="itinerary-list"></ul>
+          <div id="itinerary-map" style="height: 300px;"></div>
+          <h3>Add or Update Entry</h3>
+          <form id="itinerary-form">
+            <input type="hidden" id="itinerary-issue-number" />
+            <label for="itinerary-day">Day</label>
+            <input type="number" id="itinerary-day" min="1" required />
+            <label for="itinerary-destination">Destination</label>
+            <input type="text" id="itinerary-destination" required />
+            <label for="itinerary-activities">Activities</label>
+            <textarea id="itinerary-activities"></textarea>
+            <label for="itinerary-budget">Budget</label>
+            <input type="text" id="itinerary-budget" />
+            <label for="itinerary-photo">Photo URL</label>
+            <input type="url" id="itinerary-photo" />
+            <label for="itinerary-notes">Notes</label>
+            <textarea id="itinerary-notes"></textarea>
+            <button type="submit">Save Entry</button>
+          </form>
+          <div id="itinerary-result"></div>
+        </section>
+
+        <div class="widgets">
+          <section id="tasks">
+            <h2>Tasks</h2>
+            <img src="assets/todo.svg" alt="Checklist" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
+            <ul id="tasks-list"></ul>
+          </section>
+
+          <section id="project-board">
+            <h2>Project Board</h2>
+            <img src="assets/planning.svg" alt="Project planning board" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
+            <div id="project-columns"></div>
+          </section>
+        </div>
+      </div>
 
       <section id="new-task" class="card">
         <h2>Submit a New Task</h2>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -309,15 +309,10 @@ button:hover {
   background: var(--color-accent);
 }
 
-@media (min-width: 768px) {
-  .dashboard-grid {
-    grid-template-columns: 2fr 1fr;
-  }
-}
-
 .dashboard-grid {
   display: grid;
   gap: var(--space-lg);
+  grid-template-columns: 1fr;
 }
 
 .widgets {
@@ -326,9 +321,9 @@ button:hover {
   gap: var(--space-lg);
 }
 
-@media (max-width: 767px) {
+@media (min-width: 768px) {
   .dashboard-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: 2fr 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- structure itinerary, tasks, and project board with responsive dashboard grid
- use existing widgets sidebar for planner-like layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892748788348328991f70ee53082b57