### PR TITLE
Refine docs styles for cleaner aesthetic

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,8 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&family=Open+Sans:wght@400;600&display=swap');
 
 :root {
-  --teal: #00b4d8;
-  --coral: #ff6f61;
   --sunset: #ffb703;
   --sand: #f4e1d2;
   --bg-color: var(--sand);
@@ -21,25 +19,25 @@
   /* Spacing scale */
   --space-sm: 0.5rem;
   --space-md: 1rem;
-  --space-lg: 2rem;
-  --space-xl: 3rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
 
   /* Typography scale */
   --font-size-base: 1rem;
   --font-size-md: 1.125rem;
-  --font-size-lg: 1.5rem;
-  --font-size-xl: 2rem;
-  --font-size-xxl: 2.75rem;
+  --font-size-lg: 1.375rem;
+  --font-size-xl: 1.75rem;
+  --font-size-xxl: 2.5rem;
 
   /* Color tokens */
-  --color-primary: var(--teal);
+  --color-primary: #00b4d8;
   --color-secondary: #ffffff;
-  --color-accent: var(--coral);
+  --color-accent: #ff6f61;
   --color-accent-light: #ff9b8a;
   --color-text-inverse: #ffffff;
   --color-surface: #ffffff;
-  --color-bg-start: var(--teal);
-  --color-bg-end: var(--coral);
+  --color-bg-start: var(--color-primary);
+  --color-bg-end: var(--color-accent);
 
   /* Input tokens */
   --input-border: #cccccc;
@@ -64,7 +62,7 @@
   /* Color tokens */
   --color-primary: var(--sunset);
   --color-secondary: var(--text-color);
-  --color-accent: var(--coral);
+  --color-accent: #ff6f61;
   --color-accent-light: #ff8c82;
   --color-text-inverse: #0d1b2a;
   --color-surface: #16222f;
@@ -118,7 +116,7 @@ h3 {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: var(--teal);
+  background: var(--color-primary);
   color: #fff;
   padding: var(--space-md) var(--space-xl);
 }
@@ -169,7 +167,7 @@ section:nth-of-type(even) {
 h1,
 h2 {
   color: var(--color-primary);
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
 }
 
 h2::before {
@@ -270,6 +268,10 @@ h2::before {
   font-weight: 600;
 }
 
+.main-nav a:hover {
+  color: var(--color-accent);
+}
+
 
 .hero-icons span {
   position: absolute;
@@ -306,7 +308,7 @@ button {
 }
 
 button:hover {
-  background: var(--color-accent);
+  background: var(--color-accent-light);
 }
 
 @media (min-width: 768px) {
@@ -333,7 +335,7 @@ button:hover {
 }
 
 [data-theme="dark"] .banner {
-  background: var(--coral);
+  background: var(--color-accent);
 }
 
 [data-theme="dark"] .main-nav {
@@ -358,10 +360,6 @@ button:hover {
   padding: var(--space-md) var(--space-xl);
   font-weight: 700;
   will-change: transform, opacity;
-}
-
-.hero-cta button:hover {
-  background: var(--color-accent-light);
 }
 
 #project-selector {


### PR DESCRIPTION
## Summary
- Simplify spacing and typography scales for a lighter layout
- Replace direct teal/coral usage with color-primary/color-accent tokens
- Lighten heading shadows and unify hover styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689274890c2483288ff190e8869427d7