### PR TITLE
fix: allow repo reassignment in docs script

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -10,7 +10,7 @@ const envConfig = (typeof window !== 'undefined' && (window.ENV || window.env)) 
 const username = 'MadGodNerevar';
 const owner = username;
 
-const repo = 'holiday-adventures';
+let repo = 'holiday-adventures';
 
 // Access key for Unsplash API (required for destination images)
 const unsplashAccessKey =


### PR DESCRIPTION
## Summary
- allow `repo` variable to be reassigned in docs app

## Testing
- `node - <<'NODE' \nconst handlers = {};\nconst windowHandlers = {};\nglobal.window = {\n  location: { search: '' },\n  matchMedia: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),\n  addEventListener: (event, cb) => { windowHandlers[event] = cb; },\n  HOLIDAY_CONFIG: {},\n  ENV: {},\n};\nglobal.document = {\n  documentElement: { setAttribute: () => {}, getAttribute: () => 'light' },\n  getElementById: () => null,\n  querySelector: () => null,\n  querySelectorAll: () => [],\n  addEventListener: (event, cb) => { handlers[event] = cb; },\n};\nglobal.localStorage = { getItem: () => null, setItem: () => {} };\nglobal.fetch = async () => ({ ok: false, json: async () => ({}) });\nawait import('./docs/app.js');\nif (handlers['DOMContentLoaded']) {\n  handlers['DOMContentLoaded']();\n}\nconsole.log('Script executed without TypeError');\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_6892748dd0f4832890186456f5e577dd