### PR TITLE
feat: allow creating projects

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -646,6 +646,48 @@ function initImageFallback() {
   });
 }
 
+async function createProject(title) {
+  const token = getHolidayToken();
+  if (!token) {
+    alert('Please save a token first.');
+    return;
+  }
+  const headers = { Authorization: `bearer ${token}`, 'Content-Type': 'application/json' };
+  const ownerQuery = `
+    query($login: String!) {
+      user(login: $login) { id }
+    }
+  `;
+  const ownerRes = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query: ownerQuery, variables: { login: owner } })
+  });
+  const ownerData = await ownerRes.json();
+  const ownerId = ownerData?.data?.user?.id;
+  if (!ownerId) throw new Error('Unable to determine owner ID');
+  const mutation = `
+    mutation($input: CreateProjectV2Input!) {
+      createProjectV2(input: $input) {
+        projectV2 { id title }
+      }
+    }
+  `;
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      query: mutation,
+      variables: { input: { ownerId, title } }
+    })
+  });
+  const data = await res.json();
+  if (data.errors) {
+    throw new Error(data.errors.map(e => e.message).join(', '));
+  }
+  return data.data?.createProjectV2?.projectV2;
+}
+
 const saveBtn = document.getElementById('save-token');
 if (saveBtn) {
   saveBtn.addEventListener('click', () => {
@@ -659,6 +701,25 @@ if (saveBtn) {
   });
 }
 
+
+const projectForm = document.getElementById('new-project-form');
+if (projectForm) {
+  projectForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const title = document.getElementById('project-title').value.trim();
+    const resultEl = document.getElementById('project-create-result');
+    try {
+      const project = await createProject(title);
+      if (project) {
+        if (resultEl) resultEl.textContent = `Project "${project.title}" created`;
+        projectForm.reset();
+        loadData();
+      }
+    } catch (err) {
+      if (resultEl) resultEl.textContent = `Error: ${err.message}`;
+    }
+  });
+}
 
 const taskForm = document.getElementById('task-form');
 if (taskForm) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -85,14 +85,21 @@
         <button id="save-token">Save Token</button>
       </section>
 
-      <section id="projects" class="card">
-        <h2>Projects</h2>
-        <p id="project-description"></p>
-        <h3>Milestones</h3>
-        <ul id="project-milestones"></ul>
-        <h3>Issues</h3>
-        <ul id="project-issues"></ul>
-      </section>
+        <section id="projects" class="card">
+          <h2>Projects</h2>
+          <p id="project-description"></p>
+          <h3>Milestones</h3>
+          <ul id="project-milestones"></ul>
+          <h3>Issues</h3>
+          <ul id="project-issues"></ul>
+          <h3>Create New Project</h3>
+          <form id="new-project-form">
+            <label for="project-title">Title</label>
+            <input type="text" id="project-title" required />
+            <button type="submit">New Project</button>
+          </form>
+          <div id="project-create-result"></div>
+        </section>
 
       <section id="tasks">
         <h2>Tasks</h2>


### PR DESCRIPTION
## Summary
- add `createProject` helper to send `createProjectV2` GraphQL mutation
- expose new project form and handler that refreshes data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689277c9674c8328978670df651dc6d3