### PR TITLE
Remove project selector code and styles

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -57,18 +57,6 @@ function getHolidayToken() {
   return GITHUB_TOKEN || localStorage.getItem('HOLIDAY_TOKEN') || '';
 }
 
-function loadUserProjects() {
-  const selector = document.getElementById('project-selector');
-  if (!selector) return;
-  selector.innerHTML = '';
-  const option = document.createElement('option');
-  option.value = 'holiday-adventures';
-  option.textContent = 'holiday adventures';
-  selector.appendChild(option);
-  selector.value = 'holiday-adventures';
-  selector.style.display = 'none';
-}
-
 async function loadProjectDetails(project) {
   const descEl = document.getElementById('project-description');
   const milestonesEl = document.getElementById('project-milestones');
@@ -264,29 +252,10 @@ async function loadProjectBoard(headers) {
       projectDiv.appendChild(columnsContainer);
       boardEl.appendChild(projectDiv);
     }
-    populateProjectSelector(projects);
   } catch (err) {
     boardEl.textContent = 'Projects could not be loaded.';
     console.error(err);
   }
-}
-
-function populateProjectSelector(projects) {
-  const select = document.getElementById('project-select');
-  if (!select) return;
-  select.innerHTML = '<option value="">All Projects</option>';
-  projects.forEach(p => {
-    const opt = document.createElement('option');
-    opt.value = p.title;
-    opt.textContent = p.title;
-    select.appendChild(opt);
-  });
-  select.addEventListener('change', e => {
-    const value = e.target.value;
-    document.querySelectorAll('#project-board .project').forEach(div => {
-      div.style.display = !value || div.dataset.title === value ? '' : 'none';
-    });
-  });
 }
 
 async function loadHolidayBits(headers) {
@@ -730,8 +699,6 @@ if (itineraryForm) {
 
 // Initial load
 document.addEventListener('DOMContentLoaded', () => {
-  const selector = document.getElementById('project-selector');
-  if (selector) selector.style.display = 'none';
   repo = 'holiday-adventures';
   loadProjectDetails('holiday-adventures');
   loadData();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -349,19 +349,6 @@ button:hover {
   background: var(--color-accent-light);
 }
 
-#project-selector {
-  text-align: center;
-  margin-bottom: var(--space-xl);
-}
-
-#project-selector select {
-  padding: var(--space-sm) var(--space-md);
-  border: 1px solid var(--input-border);
-  border-radius: 6px;
-  background: var(--input-bg);
-  color: var(--input-text);
-}
-
 #planner .progress-wrapper {
   width: 100%;
   height: 1rem;


### PR DESCRIPTION
## Summary
- drop unused `loadUserProjects` and `populateProjectSelector` helpers
- remove DOM references to the obsolete `project-selector`
- eliminate `#project-selector` styles

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/holiday-adventures/package.json')*
- `node -e "const fs=require('fs');const html=fs.readFileSync('docs/index.html','utf8');console.log(/project-selector/.test(html));"`
- `node -e "const fs=require('fs');const js=fs.readFileSync('docs/app.js','utf8');console.log(/project-selector/.test(js));"`


------
https://chatgpt.com/codex/tasks/task_e_6892715e28388328a56888ef9f0992f1