### PR TITLE
refactor: centralize owner info

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3,7 +3,7 @@ import { GITHUB_TOKEN } from './config.js';
 const queryParams = new URLSearchParams(window.location.search);
 const globalConfig = window.HOLIDAY_CONFIG || {};
 const envConfig = (typeof window !== 'undefined' && (window.ENV || window.env)) || {};
-const owner = 'MadGodNerevar';
+export const owner = 'MadGodNerevar';
 const repo = 'holiday-adventures';
 
 // Access key for Unsplash API (required for destination images)

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,6 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="repo" content="holiday-adventures" />
-  <meta name="owner" content="MadGodNerevar" />
   <title>Adventure Holiday's Tracker</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />


### PR DESCRIPTION
## Summary
- remove redundant repo/owner meta tags from docs
- export owner constant and apply to GitHub fetch URLs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "const o='MadGodNerevar', r='holiday-adventures'; console.log('https://api.github.com/repos/'+o+'/'+r);"`


------
https://chatgpt.com/codex/tasks/task_e_689283200d98832889850636519ec426