### PR TITLE
Adopt card-based layout with balanced itinerary dashboard

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
       </div>
     </section>
 
-    <section id="planner" data-aos="fade-up">
+    <section id="planner" class="card" data-aos="fade-up">
       <h2>Interactive Planner</h2>
       <div class="progress-wrapper">
         <div id="planner-progress"></div>
@@ -58,7 +58,7 @@
       </ul>
     </section>
 
-    <section id="destinations" data-aos="fade-up">
+    <section id="destinations" class="card" data-aos="fade-up">
       <h2>Destination Highlights</h2>
       <div class="destinations-grid">
         <div class="destination" data-aos="zoom-in">
@@ -101,7 +101,7 @@
           <div id="project-create-result"></div>
         </section>
 
-      <section id="holiday-bits">
+      <section id="holiday-bits" class="card">
         <h2>Travel Bits</h2>
         <img src="assets/travel.svg" alt="Travel items" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
         <div id="holiday-bits-container"></div>
@@ -134,13 +134,13 @@
         </section>
 
         <div class="widgets">
-          <section id="tasks">
+          <section id="tasks" class="card">
             <h2>Tasks</h2>
             <img src="assets/todo.svg" alt="Checklist" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
             <ul id="tasks-list"></ul>
           </section>
 
-          <section id="project-board">
+          <section id="project-board" class="card">
             <h2>Project Board</h2>
             <img src="assets/planning.svg" alt="Project planning board" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
             <div id="project-columns"></div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -103,6 +103,7 @@ h1, h2, h3 {
   margin-top: 0;
   margin-bottom: var(--space-md);
   color: var(--color-primary);
+  line-height: 1.2;
 }
 
 h1 {
@@ -117,6 +118,11 @@ h3 {
   font-size: var(--font-size-md);
 }
 
+p {
+  margin-top: 0;
+  margin-bottom: var(--space-md);
+}
+
 .banner {
   display: flex;
   justify-content: space-between;
@@ -128,19 +134,6 @@ h3 {
 
 section {
   margin-bottom: var(--space-xl);
-  border: 1px solid var(--section-border);
-  padding: var(--space-lg);
-  border-radius: 8px;
-  box-shadow: 0 1px 3px var(--section-shadow);
-  color: var(--section-text);
-}
-
-section:nth-of-type(odd) {
-  background: var(--section-bg-odd);
-}
-
-section:nth-of-type(even) {
-  background: var(--section-bg-even);
 }
 
 .section-hidden {
@@ -298,8 +291,8 @@ h2::before {
 .card {
   background: var(--color-surface);
   border-radius: 8px;
-  box-shadow: 0 1px 3px var(--section-shadow);
-  padding: var(--space-lg);
+  box-shadow: 0 2px 4px var(--section-shadow);
+  padding: var(--space-xl);
 }
 
 button {
@@ -318,19 +311,20 @@ button:hover {
 
 .dashboard-grid {
   display: grid;
-  gap: var(--space-lg);
+  gap: var(--space-xl);
   grid-template-columns: 1fr;
+  align-items: start;
 }
 
 .widgets {
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
+  gap: var(--space-xl);
 }
 
 @media (min-width: 768px) {
   .dashboard-grid {
-    grid-template-columns: 2fr 1fr;
+    grid-template-columns: 3fr 2fr;
   }
 }
 
@@ -364,7 +358,7 @@ form.card button {
 }
 
 [data-theme="dark"] .card {
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
 }
 
 /* Additional layout and animation sections */


### PR DESCRIPTION
## Summary
- Refine typography and spacing for headings and paragraphs.
- Replace section borders with reusable card containers and lighter shadows.
- Balance itinerary and widgets via a two-column dashboard grid.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892832749d48328898c80db05dd6633