### PR TITLE
Skip markdown files in Holiday Bits

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -388,22 +388,18 @@ async function loadHolidayBits(headers) {
       h3.textContent = title;
       sectionDiv.appendChild(h3);
       const ul = document.createElement('ul');
-      files.forEach(file => {
-        if (file.type === 'file') {
+      files
+        .filter(file => file.type === 'file' && !file.name.endsWith('.md'))
+        .forEach(file => {
           const li = document.createElement('li');
-          const name = file.name.replace(/\.md$/, '').replace(/-/g, ' ');
-          if (file.name.endsWith('.md')) {
-            li.textContent = name;
-          } else {
-            const a = document.createElement('a');
-            a.href = file.html_url;
-            a.textContent = name;
-            a.target = '_blank';
-            li.appendChild(a);
-          }
+          const name = file.name.replace(/-/g, ' ');
+          const a = document.createElement('a');
+          a.href = file.html_url;
+          a.textContent = name;
+          a.target = '_blank';
+          li.appendChild(a);
           ul.appendChild(li);
-        }
-      });
+        });
       sectionDiv.appendChild(ul);
       container.appendChild(sectionDiv);
     } catch (err) {


### PR DESCRIPTION
## Summary
- show only non-Markdown assets in Holiday Bits list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899e8ca952c8328bb98915dad6c81c6