### PR TITLE
Switch project terminology to destination

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -52,9 +52,9 @@ function getHolidayToken() {
 }
 
 async function loadProjectDetails(project) {
-  const descEl = document.getElementById('project-description');
-  const milestonesEl = document.getElementById('project-milestones');
-  const issuesEl = document.getElementById('project-issues');
+  const descEl = document.getElementById('destination-description');
+  const milestonesEl = document.getElementById('destination-milestones');
+  const issuesEl = document.getElementById('destination-issues');
   if (descEl) descEl.textContent = '';
   if (milestonesEl) milestonesEl.innerHTML = '';
   if (issuesEl) issuesEl.innerHTML = '';
@@ -193,9 +193,9 @@ async function loadTasks(headers, projectId) {
 }
 
 async function loadProjectBoard(headers, projectId) {
-  const boardEl = document.getElementById('project-columns');
+  const boardEl = document.getElementById('destination-columns');
   if (!boardEl) {
-    console.warn('Project columns element not found');
+    console.warn('Destination columns element not found');
     return;
   }
   boardEl.innerHTML = '';
@@ -282,7 +282,7 @@ async function loadProjectBoard(headers, projectId) {
       projects = projectData?.data?.repository?.projectsV2?.nodes || [];
     }
     if (!projects.length) {
-      boardEl.textContent = 'No projects found';
+      boardEl.textContent = 'No destinations found';
       return;
     }
     for (const project of projects) {
@@ -336,17 +336,17 @@ async function loadProjectBoard(headers, projectId) {
       projectDiv.appendChild(columnsContainer);
       boardEl.appendChild(projectDiv);
     }
-    populateTaskProjectSelector(projects);
+    populateTaskDestinationSelector(projects);
   } catch (err) {
-    boardEl.textContent = 'Projects could not be loaded.';
+    boardEl.textContent = 'Destinations could not be loaded.';
     console.error(err);
   }
 }
 
-function populateTaskProjectSelector(projects) {
-  const select = document.getElementById('task-project');
+function populateTaskDestinationSelector(projects) {
+  const select = document.getElementById('task-destination');
   if (!select) return;
-  select.innerHTML = '<option value="">Select Project</option>';
+  select.innerHTML = '<option value="">Select Destination</option>';
   projects.forEach(p => {
     const opt = document.createElement('option');
     opt.value = p.id;
@@ -364,7 +364,7 @@ async function loadHolidayBits(headers) {
     { path: 'ideas', title: 'Ideas' },
     { path: 'packing-lists', title: 'Packing Lists' },
     { path: 'itinerary-templates', title: 'Itinerary Templates' },
-    { path: 'projects', title: 'Projects' }
+    { path: 'projects', title: 'Destinations' }
   ];
   for (const { path, title } of sections) {
     try {
@@ -752,17 +752,17 @@ if (saveBtn) {
 }
 
 
-const projectForm = document.getElementById('new-project-form');
-if (projectForm) {
-  projectForm.addEventListener('submit', async e => {
+const destinationForm = document.getElementById('new-destination-form');
+if (destinationForm) {
+  destinationForm.addEventListener('submit', async e => {
     e.preventDefault();
-    const title = document.getElementById('project-title').value.trim();
-    const resultEl = document.getElementById('project-create-result');
+    const title = document.getElementById('destination-title').value.trim();
+    const resultEl = document.getElementById('destination-create-result');
     try {
       const project = await createProject(title);
       if (project) {
-        if (resultEl) resultEl.textContent = `Project "${project.title}" created`;
-        projectForm.reset();
+        if (resultEl) resultEl.textContent = `Destination "${project.title}" created`;
+        destinationForm.reset();
         loadData();
       }
     } catch (err) {
@@ -782,7 +782,7 @@ if (taskForm) {
     }
     const title = document.getElementById('task-title').value;
     const body = document.getElementById('task-body').value;
-    const projectId = document.getElementById('task-project').value;
+    const projectId = document.getElementById('task-destination').value;
     const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
       method: 'POST',
       headers: {

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,9 +21,9 @@
   </header>
 
   <nav class="main-nav">
-    <a href="#projects"><span class="nav-icon">📁</span>Projects</a>
+    <a href="#destinations"><span class="nav-icon">📁</span>Destinations</a>
     <a href="#tasks"><span class="nav-icon">📝</span>Tasks</a>
-    <a href="#project-board"><span class="nav-icon">📋</span>Project Board</a>
+    <a href="#destination-board"><span class="nav-icon">📋</span>Destination Board</a>
     <a href="#holiday-bits"><span class="nav-icon">🎒</span>Holiday Bits</a>
     <a href="#itinerary"><span class="nav-icon">🗺️</span>Itinerary</a>
   </nav>
@@ -56,7 +56,7 @@
       </ul>
     </section>
 
-    <section id="destinations" class="card" data-aos="fade-up">
+    <section id="destination-highlights" class="card" data-aos="fade-up">
       <h2>Destination Highlights</h2>
       <div class="destinations-grid">
         <div class="destination" data-aos="zoom-in">
@@ -83,20 +83,21 @@
         <button id="save-token">Save Token</button>
       </section>
 
-        <section id="projects" class="card">
-          <h2>Projects</h2>
-          <p id="project-description"></p>
+        <section id="destinations" class="card">
+          <h2>Destinations</h2>
+          <p id="destination-description"></p>
           <h3>Milestones</h3>
-          <ul id="project-milestones"></ul>
+          <ul id="destination-milestones"></ul>
           <h3>Issues</h3>
-          <ul id="project-issues"></ul>
-          <h3>Create New Project</h3>
-          <form id="new-project-form">
-            <label for="project-title">Title</label>
-            <input type="text" id="project-title" required />
-            <button type="submit">New Project</button>
+          <ul id="destination-issues"></ul>
+          <h3>Create New Destination</h3>
+          <form id="new-destination-form">
+            <label for="destination-title">Title</label>
+            <input type="text" id="destination-title" required />
+            <button type="submit">New Destination</button>
+            
           </form>
-          <div id="project-create-result"></div>
+          <div id="destination-create-result"></div>
         </section>
 
       <section id="holiday-bits" class="card">
@@ -138,10 +139,10 @@
             <ul id="tasks-list"></ul>
           </section>
 
-          <section id="project-board" class="card">
-            <h2>Project Board</h2>
-            <img src="assets/planning.svg" alt="Project planning board" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
-            <div id="project-columns"></div>
+          <section id="destination-board" class="card">
+            <h2>Destination Board</h2>
+            <img src="assets/planning.svg" alt="Destination planning board" class="section-image" loading="lazy" referrerpolicy="no-referrer" />
+            <div id="destination-columns"></div>
           </section>
         </div>
       </div>
@@ -154,8 +155,8 @@
           <input type="text" id="task-title" required />
           <label for="task-body">Description</label>
           <textarea id="task-body" required></textarea>
-          <label for="task-project">Project</label>
-          <select id="task-project"></select>
+          <label for="task-destination">Destination</label>
+          <select id="task-destination"></select>
           <button type="submit">Create Task</button>
         </form>
         <div id="task-result"></div>


### PR DESCRIPTION
## Summary
- rename Projects navigation and section to Destinations
- update board and task form to use destination-focused labels and IDs
- sync app.js with new destination element IDs and messages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f1a9cb2883288dade849d44afc4e