### PR TITLE
Improve dark mode toggle accessibility

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -27,13 +27,19 @@ function initTheme() {
   const media = window.matchMedia('(prefers-color-scheme: dark)');
   const currentTheme = storedTheme || (media.matches ? 'dark' : 'light');
   root.setAttribute('data-theme', currentTheme);
-  if (toggle) toggle.textContent = currentTheme === 'dark' ? '☀️' : '🌙';
+  if (toggle) {
+    toggle.textContent = currentTheme === 'dark' ? '☀️' : '🌙';
+    toggle.setAttribute('aria-pressed', currentTheme === 'dark');
+  }
 
   media.addEventListener('change', e => {
     if (!localStorage.getItem('theme')) {
       const newTheme = e.matches ? 'dark' : 'light';
       root.setAttribute('data-theme', newTheme);
-      if (toggle) toggle.textContent = newTheme === 'dark' ? '☀️' : '🌙';
+      if (toggle) {
+        toggle.textContent = newTheme === 'dark' ? '☀️' : '🌙';
+        toggle.setAttribute('aria-pressed', newTheme === 'dark');
+      }
     }
   });
 
@@ -43,6 +49,7 @@ function initTheme() {
       root.setAttribute('data-theme', theme);
       localStorage.setItem('theme', theme);
       toggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+      toggle.setAttribute('aria-pressed', theme === 'dark');
     });
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
 <body>
   <header class="banner">
     <h1>✈️ Adventure Holiday's Tracker ✈️</h1>
-    <button id="dark-mode-toggle" aria-label="Toggle dark mode">🌙</button>
+    <button id="dark-mode-toggle" aria-label="Toggle dark mode" aria-pressed="false">🌙</button>
   </header>
 
   <nav class="main-nav">


### PR DESCRIPTION
## Summary
- Add `aria-pressed` state to dark mode button
- Sync button `aria-pressed` with theme setting in `initTheme`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a5ea891a083288c13f6d335b3409d