### PR TITLE
Add color-scheme meta tag to docs index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="light dark" />
   <title>Adventure Holiday's Tracker</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />


### PR DESCRIPTION
## Summary
- ensure docs page declares supported color schemes for light and dark modes

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a5eaaa3a48328a3642d2eff7e6edb