### PR TITLE
Rename board loader to loadDestinationBoard

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -192,7 +192,7 @@ async function loadTasks(headers, destinationId) {
   }
 }
 
-async function loadProjectBoard(headers, projectId) {
+async function loadDestinationBoard(headers, projectId) {
   const boardEl = document.getElementById('destination-columns');
   if (!boardEl) {
     console.warn('Destination columns element not found');


### PR DESCRIPTION
## Summary
- Rename `loadProjectBoard` to `loadDestinationBoard` and keep call site consistent

## Testing
- `node board-test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_689a5ebcb6488328ba2230b93b957617