### PR TITLE
Add meta color-scheme for dark mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="light dark" />
   <title>Adventure Holiday's Tracker</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />


### PR DESCRIPTION
## Summary
- ensure docs support dark mode forms by adding `color-scheme` meta tag

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_689a5ec3604883288a0c1c19aeba8b0c